### PR TITLE
Remove ignoreErrors entries from phpstan config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,10 @@
 		"szepeviktor/phpstan-wordpress": "*",
 		"php-stubs/woocommerce-stubs": "*",
 		"wpsyntex/polylang-stubs": "dev-master"
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	}
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,7 +9,5 @@ parameters:
 	checkMissingIterableValueType: false
 	ignoreErrors:
 		- '#^Function apply_filters invoked with [34567] parameters, 2 required\.$#'
-		- '#^Function remove_filter invoked with [4567] parameters, 2-3 required\.$#'
-		- '#^Function remove_action invoked with [4567] parameters, 2-3 required\.$#'
 	bootstrapFiles:
-	- vendor/wpsyntex/polylang-stubs/bootstrap.php
+		- vendor/wpsyntex/polylang-stubs/bootstrap.php


### PR DESCRIPTION
This removes 2 unnecessary entries from the `ignoreErrors` section of the phpstan config file.
The removed entries were ignoring errors about the 3rd and 4th arguments passed to `remove_action()` and `remove_filter()`.
However, no calls were found in the plugin's code, meaning these errors were ignored for no nothing.