### PR TITLE
Update PHPStan config to use polylang-phpstan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
 		"automattic/vipwpcs": "*",
 		"phpcompatibility/phpcompatibility-wp": "*",
 		"szepeviktor/phpstan-wordpress": "*",
-		"php-stubs/woocommerce-stubs": "*",
+		"phpstan/phpstan": "<1.7",
+		"wpsyntex/polylang-phpstan": "^1.0",
 		"wpsyntex/polylang-stubs": "dev-master"
 	},
 	"scripts": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,7 +7,5 @@ parameters:
 	dynamicConstantNames:
 		- POLYLANG_VERSION
 	checkMissingIterableValueType: false
-	ignoreErrors:
-		- '#^Function apply_filters invoked with [34567] parameters, 2 required\.$#'
 	bootstrapFiles:
-		- vendor/wpsyntex/polylang-stubs/bootstrap.php
+		- vendor/wpsyntex/polylang-stubs/polylang-stubs.php


### PR DESCRIPTION
Also remove ignored errors for `apply_filters()` as it's now taken into account by phpstan-wordpress.