### PR TITLE
Adapt to Polylang 3.4

### DIFF
--- a/src/NoLangObjects.php
+++ b/src/NoLangObjects.php
@@ -49,24 +49,6 @@ class NoLangObjects extends AbstractAction {
 	 * @return void
 	 */
 	protected function handle() {
-		$wpml_settings = get_option( 'icl_sitepress_settings' );
-
-		if ( ! is_array( $wpml_settings ) ) {
-			return; // Something's wrong.
-		}
-
-		$nolang = PLL()->model->get_objects_with_no_lang( WPML_TO_POLYLANG_QUERY_BATCH_SIZE );
-
-		while ( $nolang ) {
-			if ( ! empty( $nolang['posts'] ) ) {
-				PLL()->model->set_language_in_mass( 'post', $nolang['posts'], $wpml_settings['default_language'] );
-			}
-
-			if ( ! empty( $nolang['terms'] ) ) {
-				PLL()->model->set_language_in_mass( 'term', $nolang['terms'], $wpml_settings['default_language'] );
-			}
-
-			$nolang = PLL()->model->get_objects_with_no_lang( WPML_TO_POLYLANG_QUERY_BATCH_SIZE );
-		}
+		PLL()->model->set_language_in_mass();
 	}
 }

--- a/src/Posts.php
+++ b/src/Posts.php
@@ -49,7 +49,7 @@ class Posts extends AbstractObjects {
 		$languages = [];
 
 		foreach ( PLL()->model->get_languages_list() as $lang ) {
-			$languages[ $lang->slug ] = $lang->term_taxonomy_id;
+			$languages[ $lang->slug ] = $lang->get_tax_prop( 'language', 'term_taxonomy_id' );
 		}
 
 		return $languages;

--- a/src/Terms.php
+++ b/src/Terms.php
@@ -49,7 +49,7 @@ class Terms extends AbstractObjects {
 		$languages = [];
 
 		foreach ( PLL()->model->get_languages_list() as $lang ) {
-			$languages[ $lang->slug ] = $lang->tl_term_taxonomy_id;
+			$languages[ $lang->slug ] = $lang->get_tax_prop( 'term_language', 'term_taxonomy_id' );
 		}
 
 		return $languages;

--- a/wpml-to-polylang.php
+++ b/wpml-to-polylang.php
@@ -44,8 +44,8 @@ namespace WP_Syntex\WPML_To_Polylang;
 defined( 'ABSPATH' ) || exit;
 
 define( 'WPML_TO_POLYLANG_VERSION', '0.5' );
-define( 'WPML_TO_POLYLANG_MIN_WP_VERSION', '4.9' );
-define( 'WPML_TO_POLYLANG_MIN_PLL_VERSION', '2.8' );
+define( 'WPML_TO_POLYLANG_MIN_WP_VERSION', '5.8' );
+define( 'WPML_TO_POLYLANG_MIN_PLL_VERSION', '3.4' );
 
 if ( ! defined( 'WPML_TO_POLYLANG_QUERY_BATCH_SIZE' ) ) {
 	define( 'WPML_TO_POLYLANG_QUERY_BATCH_SIZE', 5000 ); // Limits the size of database queries.


### PR DESCRIPTION
- Require Polylang 3.4 to avoid extra maintenance.
- Remove usage of deprecated properties
- Fix infinite loop when processing objects with no language (due to drastic changes in the way `PLL_Model::set_language_in_mass()` works.