### PR TITLE
Fix array key in `Posts::getTranslatedPostTypes()`

### DIFF
--- a/src/Posts.php
+++ b/src/Posts.php
@@ -154,7 +154,7 @@ class Posts extends AbstractObjects {
 		$types    = [ 'post', 'page', 'wp_block' ];
 		$settings = get_option( 'icl_sitepress_settings' );
 
-		if ( is_array( $settings ) && is_array( $settings['taxonomies_sync_option'] ) ) {
+		if ( is_array( $settings ) && is_array( $settings['custom_posts_sync_option'] ) ) {
 			$icl_types = array_keys( $settings['custom_posts_sync_option'] );
 			$icl_types = array_filter( $icl_types, 'is_string' );
 			$types     = array_merge( $types, $icl_types );

--- a/src/Posts.php
+++ b/src/Posts.php
@@ -158,6 +158,7 @@ class Posts extends AbstractObjects {
 			$icl_types = array_keys( $settings['custom_posts_sync_option'] );
 			$icl_types = array_filter( $icl_types, 'is_string' );
 			$types     = array_merge( $types, $icl_types );
+			$types     = array_unique( $types );
 		}
 
 		$types = array_diff( $types, [ 'wp_template' ] );

--- a/src/Terms.php
+++ b/src/Terms.php
@@ -167,6 +167,7 @@ class Terms extends AbstractObjects {
 			$icl_taxonomies = array_keys( $settings['taxonomies_sync_option'] );
 			$icl_taxonomies = array_filter( $icl_taxonomies, 'is_string' );
 			$taxonomies     = array_merge( $taxonomies, $icl_taxonomies );
+			$taxonomies     = array_unique( $taxonomies );
 		}
 
 		$taxonomies = array_diff( $taxonomies, [ 'wp_theme', 'wp_template_part_area' ] );


### PR DESCRIPTION
Copy/Paste drama, the array should be `custom_posts_sync_option`.

Bonus: `array_unique()`, so the hard-coded values are not duplicated.