### PR TITLE
Add support of ACF Multilingual

### DIFF
--- a/src/ACFFields.php
+++ b/src/ACFFields.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * PHP version 5.6
+ *
+ * @package wpml-to-polylang
+ */
+
+namespace WP_Syntex\WPML_To_Polylang;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Handles the ACF fields.
+ *
+ * @since 0.6
+ */
+class ACFFields extends AbstractSteppable {
+	const ACFML_KEY = 'wpml_cf_preferences';
+	const TYPES     = [
+		0 => 'none', // WPML_IGNORE_CUSTOM_FIELD.
+		1 => 'copy', // WPML_COPY_CUSTOM_FIELD.
+		2 => 'translate', // WPML_TRANSLATE_CUSTOM_FIELD.
+		3 => 'copy_once', // WPML_COPY_ONCE_CUSTOM_FIELD.
+	];
+
+	/**
+	 * Returns the action name.
+	 *
+	 * @since 0.6
+	 *
+	 * @return string
+	 */
+	public function getName() {
+		return 'process_acf_fields';
+	}
+
+	/**
+	 * Returns the processing message.
+	 *
+	 * @since 0.6
+	 *
+	 * @return string
+	 */
+	protected function getMessage() {
+		return esc_html__( 'Processing ACF fields', 'wpml-to-polylang' );
+	}
+
+	/**
+	 * Processes the ACF fields.
+	 *
+	 * @since 0.6
+	 *
+	 * @return void
+	 */
+	protected function handle() {
+		global $wpdb;
+
+		$batch_size = absint( WPML_TO_POLYLANG_QUERY_BATCH_SIZE / 100 ); // 50 by default, to limit the size of the UPDATE query.
+		$offset     = absint( ( $this->step * $batch_size ) - $batch_size );
+		$results    = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT ID, post_content
+				FROM {$wpdb->posts}
+				WHERE post_type = 'acf-field' AND post_content LIKE %s
+				ORDER BY ID ASC
+				LIMIT %d, %d",
+				'%"' . $wpdb->esc_like( self::ACFML_KEY ) . '"%',
+				$offset,
+				$batch_size
+			)
+		);
+
+		$values = [];
+
+		foreach ( $results as $field ) {
+			$post_content = maybe_unserialize( $field->post_content );
+
+			if ( ! is_array( $post_content ) ) {
+				// Unserialization failure.
+				continue;
+			}
+
+			if ( ! is_numeric( $post_content[ self::ACFML_KEY ] ) || ! isset( self::TYPES[ $post_content[ self::ACFML_KEY ] ] ) ) {
+				// Should not happen.
+				$post_content['translations'] = 'none';
+			} else {
+				$post_content['translations'] = self::TYPES[ $post_content[ self::ACFML_KEY ] ];
+			}
+
+			$post_content = serialize( $post_content ); // PHPCS:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+
+			if ( ! is_string( $post_content ) ) {
+				// Serialization failure.
+				continue;
+			}
+
+			$values[ $field->ID ] = sprintf( "WHEN %d THEN '%s'", $field->ID, addcslashes( esc_sql( $post_content ), "'" ) );
+		} // End foreach.
+
+		if ( empty( $values ) ) {
+			return;
+		}
+
+		// Update the whole batch in one query.
+		$wpdb->query(
+			sprintf(
+				"UPDATE {$wpdb->posts}
+				SET post_content = CASE ID
+					%s
+					ELSE post_content
+				END
+				WHERE ID IN (%s)",
+				implode( "\n", $values ), // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+				implode( "\n", array_keys( $values ) ) // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			)
+		);
+	}
+
+	/**
+	 * Returns the number of ACF fields to update.
+	 *
+	 * @since 0.6
+	 *
+	 * @return int
+	 */
+	protected function getTotal() {
+		global $wpdb;
+
+		return (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*)
+				FROM {$wpdb->posts}
+				WHERE post_type = 'acf-field' AND post_content LIKE %s",
+				'%"' . $wpdb->esc_like( self::ACFML_KEY ) . '"%'
+			)
+		);
+	}
+}

--- a/src/ACFFields.php
+++ b/src/ACFFields.php
@@ -24,22 +24,6 @@ class ACFFields extends AbstractSteppable {
 	];
 
 	/**
-	 * Batch size.
-	 *
-	 * @var int
-	 */
-	protected $batch_size;
-
-	/**
-	 * Constructor.
-	 *
-	 * @since 0.6
-	 */
-	public function __construct() {
-		$this->batch_size = absint( WPML_TO_POLYLANG_QUERY_BATCH_SIZE / 100 ); // 50 by default, to limit the size of the UPDATE query.
-	}
-
-	/**
 	 * Returns the action name.
 	 *
 	 * @since 0.6
@@ -71,8 +55,9 @@ class ACFFields extends AbstractSteppable {
 	protected function handle() {
 		global $wpdb;
 
-		$offset  = absint( ( $this->step * $this->batch_size ) - $this->batch_size );
-		$results = $wpdb->get_results(
+		$batch_size = $this->getBatchSyze();
+		$offset     = absint( ( $this->step * $batch_size ) - $batch_size );
+		$results    = $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT ID, post_content
 				FROM {$wpdb->posts}
@@ -80,7 +65,7 @@ class ACFFields extends AbstractSteppable {
 				ORDER BY ID ASC
 				LIMIT %d OFFSET %d",
 				'%"' . $wpdb->esc_like( self::ACFML_KEY ) . '"%',
-				$this->batch_size,
+				$batch_size,
 				$offset
 			)
 		);
@@ -129,6 +114,17 @@ class ACFFields extends AbstractSteppable {
 				implode( "\n", array_keys( $values ) ) // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 			)
 		);
+	}
+
+	/**
+	 * Returns the batch size.
+	 *
+	 * @since 0.6
+	 *
+	 * @return int A positive integer.
+	 */
+	protected function getBatchSyze() {
+		return absint( WPML_TO_POLYLANG_QUERY_BATCH_SIZE / 100 ); // 50 by default, to limit the size of the UPDATE query.
 	}
 
 	/**

--- a/src/ACFFields.php
+++ b/src/ACFFields.php
@@ -94,7 +94,7 @@ class ACFFields extends AbstractSteppable {
 				continue;
 			}
 
-			$values[ $field->ID ] = sprintf( "WHEN %d THEN '%s'", $field->ID, addcslashes( esc_sql( $post_content ), "'" ) );
+			$values[ $field->ID ] = [ $field->ID, $post_content ];
 		} // End foreach.
 
 		if ( empty( $values ) ) {
@@ -103,15 +103,13 @@ class ACFFields extends AbstractSteppable {
 
 		// Update the whole batch in one query.
 		$wpdb->query(
-			sprintf(
-				"UPDATE {$wpdb->posts}
-				SET post_content = CASE ID
-					%s
-					ELSE post_content
-				END
-				WHERE ID IN (%s)",
-				implode( "\n", $values ), // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-				implode( "\n", array_keys( $values ) ) // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			$wpdb->prepare(
+				sprintf(
+					"UPDATE {$wpdb->posts} SET post_content = (CASE ID %s ELSE post_content END) WHERE ID IN (%s)",
+					implode( ' ', array_fill( 0, count( $values ), 'WHEN %d THEN %s' ) ),
+					implode( ',', array_fill( 0, count( $values ), '%d' ) )
+				),
+				array_merge( array_merge( ...$values ), array_keys( $values ) )
 			)
 		);
 	}

--- a/src/ACFFields.php
+++ b/src/ACFFields.php
@@ -78,10 +78,10 @@ class ACFFields extends AbstractSteppable {
 				FROM {$wpdb->posts}
 				WHERE post_type = 'acf-field' AND post_content LIKE %s
 				ORDER BY ID ASC
-				LIMIT %d, %d",
+				LIMIT %d OFFSET %d",
 				'%"' . $wpdb->esc_like( self::ACFML_KEY ) . '"%',
-				$offset,
-				$this->batch_size
+				$this->batch_size,
+				$offset
 			)
 		);
 

--- a/src/ACFFields.php
+++ b/src/ACFFields.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Handles the ACF fields.
  *
- * @since 0.6
+ * @since 0.7
  */
 class ACFFields extends AbstractSteppable {
 	const ACFML_KEY = 'wpml_cf_preferences';
@@ -26,7 +26,7 @@ class ACFFields extends AbstractSteppable {
 	/**
 	 * Returns the action name.
 	 *
-	 * @since 0.6
+	 * @since 0.7
 	 *
 	 * @return string
 	 */
@@ -37,7 +37,7 @@ class ACFFields extends AbstractSteppable {
 	/**
 	 * Returns the processing message.
 	 *
-	 * @since 0.6
+	 * @since 0.7
 	 *
 	 * @return string
 	 */
@@ -48,7 +48,7 @@ class ACFFields extends AbstractSteppable {
 	/**
 	 * Processes the ACF fields.
 	 *
-	 * @since 0.6
+	 * @since 0.7
 	 *
 	 * @return void
 	 */
@@ -117,7 +117,7 @@ class ACFFields extends AbstractSteppable {
 	/**
 	 * Returns the batch size.
 	 *
-	 * @since 0.6
+	 * @since 0.7
 	 *
 	 * @return int A positive integer.
 	 */
@@ -128,7 +128,7 @@ class ACFFields extends AbstractSteppable {
 	/**
 	 * Returns the number of ACF fields to update.
 	 *
-	 * @since 0.6
+	 * @since 0.7
 	 *
 	 * @return int
 	 */

--- a/src/ACFFields.php
+++ b/src/ACFFields.php
@@ -24,6 +24,22 @@ class ACFFields extends AbstractSteppable {
 	];
 
 	/**
+	 * Batch size.
+	 *
+	 * @var int
+	 */
+	protected $batch_size;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 0.6
+	 */
+	public function __construct() {
+		$this->batch_size = absint( WPML_TO_POLYLANG_QUERY_BATCH_SIZE / 100 ); // 50 by default, to limit the size of the UPDATE query.
+	}
+
+	/**
 	 * Returns the action name.
 	 *
 	 * @since 0.6
@@ -55,9 +71,8 @@ class ACFFields extends AbstractSteppable {
 	protected function handle() {
 		global $wpdb;
 
-		$batch_size = absint( WPML_TO_POLYLANG_QUERY_BATCH_SIZE / 100 ); // 50 by default, to limit the size of the UPDATE query.
-		$offset     = absint( ( $this->step * $batch_size ) - $batch_size );
-		$results    = $wpdb->get_results(
+		$offset  = absint( ( $this->step * $this->batch_size ) - $this->batch_size );
+		$results = $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT ID, post_content
 				FROM {$wpdb->posts}
@@ -66,7 +81,7 @@ class ACFFields extends AbstractSteppable {
 				LIMIT %d, %d",
 				'%"' . $wpdb->esc_like( self::ACFML_KEY ) . '"%',
 				$offset,
-				$batch_size
+				$this->batch_size
 			)
 		);
 

--- a/src/AbstractSteppable.php
+++ b/src/AbstractSteppable.php
@@ -26,6 +26,17 @@ abstract class AbstractSteppable extends AbstractAction {
 	abstract protected function getTotal();
 
 	/**
+	 * Returns the batch size.
+	 *
+	 * @since 0.6
+	 *
+	 * @return int A positive integer.
+	 */
+	protected function getBatchSyze() {
+		return WPML_TO_POLYLANG_QUERY_BATCH_SIZE;
+	}
+
+	/**
 	 * Returns the action completion percentage.
 	 *
 	 * @since 0.5
@@ -37,7 +48,7 @@ abstract class AbstractSteppable extends AbstractAction {
 		$total      = $this->getTotal();
 
 		if ( $total ) {
-			$percentage = ( $this->step * WPML_TO_POLYLANG_QUERY_BATCH_SIZE ) / $total * 100;
+			$percentage = ( $this->step * $this->getBatchSyze() ) / $total * 100;
 			$percentage = (int) ceil( $percentage );
 		}
 

--- a/src/AbstractSteppable.php
+++ b/src/AbstractSteppable.php
@@ -28,7 +28,7 @@ abstract class AbstractSteppable extends AbstractAction {
 	/**
 	 * Returns the batch size.
 	 *
-	 * @since 0.6
+	 * @since 0.7
 	 *
 	 * @return int A positive integer.
 	 */

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -44,6 +44,7 @@ class Plugin {
 			new NoLangObjects(),
 			new Strings(),
 			new Options(),
+			new ACFFields(),
 		];
 
 		$nextAction = '';

--- a/src/Posts.php
+++ b/src/Posts.php
@@ -96,15 +96,17 @@ class Posts extends AbstractObjects {
 	protected function getWPMLTranslationIds() {
 		global $wpdb;
 
-		$trids = $wpdb->get_col(
+		$batch_size = $this->getBatchSyze();
+		$offset     = absint( ( $this->step * $batch_size ) - $batch_size );
+		$trids      = $wpdb->get_col(
 			sprintf(
 				"SELECT DISTINCT trid
 				FROM {$wpdb->prefix}icl_translations
 				WHERE SUBSTR( element_type, 6 ) IN ( '%s' )
 				LIMIT %d, %d",
 				implode( "', '", esc_sql( $this->getTranslatedPostTypes() ) ),
-				absint( $this->step * WPML_TO_POLYLANG_QUERY_BATCH_SIZE - WPML_TO_POLYLANG_QUERY_BATCH_SIZE ),
-				absint( WPML_TO_POLYLANG_QUERY_BATCH_SIZE )
+				$offset,
+				$batch_size
 			)
 		);
 

--- a/src/Posts.php
+++ b/src/Posts.php
@@ -97,7 +97,7 @@ class Posts extends AbstractObjects {
 		global $wpdb;
 
 		$batch_size = $this->getBatchSyze();
-		$offset     = absint( ( $this->step * $batch_size ) - $batch_size );
+		$offset     = ( $this->step * $batch_size ) - $batch_size;
 		$trids      = $wpdb->get_col(
 			sprintf(
 				"SELECT DISTINCT trid
@@ -105,8 +105,8 @@ class Posts extends AbstractObjects {
 				WHERE SUBSTR( element_type, 6 ) IN ( '%s' )
 				LIMIT %d, %d",
 				implode( "', '", esc_sql( $this->getTranslatedPostTypes() ) ),
-				$offset,
-				$batch_size
+				absint( $offset ),
+				absint( $batch_size )
 			)
 		);
 

--- a/src/Strings.php
+++ b/src/Strings.php
@@ -101,7 +101,8 @@ class Strings extends AbstractSteppable {
 	protected function getWPMLStringsTranslations() {
 		global $wpdb;
 
-		$offset = ( $this->step * WPML_TO_POLYLANG_QUERY_BATCH_SIZE ) - WPML_TO_POLYLANG_QUERY_BATCH_SIZE;
+		$batch_size = $this->getBatchSyze();
+		$offset     = absint( ( $this->step * $batch_size ) - $batch_size );
 
 		/**
 		 * WPML string translations.
@@ -116,8 +117,8 @@ class Strings extends AbstractSteppable {
 				WHERE s.context NOT IN ( '%s' )
 				LIMIT %d, %d",
 				implode( "', '", esc_sql( $this->getDomains() ) ),
-				absint( $offset ),
-				absint( WPML_TO_POLYLANG_QUERY_BATCH_SIZE )
+				$offset,
+				$batch_size
 			)
 		);
 

--- a/src/Strings.php
+++ b/src/Strings.php
@@ -102,7 +102,7 @@ class Strings extends AbstractSteppable {
 		global $wpdb;
 
 		$batch_size = $this->getBatchSyze();
-		$offset     = absint( ( $this->step * $batch_size ) - $batch_size );
+		$offset     = ( $this->step * $batch_size ) - $batch_size;
 
 		/**
 		 * WPML string translations.
@@ -117,8 +117,8 @@ class Strings extends AbstractSteppable {
 				WHERE s.context NOT IN ( '%s' )
 				LIMIT %d, %d",
 				implode( "', '", esc_sql( $this->getDomains() ) ),
-				$offset,
-				$batch_size
+				absint( $offset ),
+				absint( $batch_size )
 			)
 		);
 

--- a/src/Terms.php
+++ b/src/Terms.php
@@ -99,7 +99,9 @@ class Terms extends AbstractObjects {
 	protected function getWPMLTranslationIds() {
 		global $wpdb;
 
-		$trids = $wpdb->get_col(
+		$batch_size = $this->getBatchSyze();
+		$offset     = absint( ( $this->step * $batch_size ) - $batch_size );
+		$trids      = $wpdb->get_col(
 			sprintf(
 				"SELECT DISTINCT wpml.trid
 				FROM {$wpdb->term_taxonomy} AS tt
@@ -109,8 +111,8 @@ class Terms extends AbstractObjects {
 				WHERE tt.taxonomy IN ( '%s' )
 				LIMIT %d, %d",
 				implode( "', '", esc_sql( $this->getTranslatedTaxonomies() ) ),
-				absint( $this->step * WPML_TO_POLYLANG_QUERY_BATCH_SIZE - WPML_TO_POLYLANG_QUERY_BATCH_SIZE ),
-				absint( WPML_TO_POLYLANG_QUERY_BATCH_SIZE )
+				$offset,
+				$batch_size
 			)
 		);
 

--- a/src/Terms.php
+++ b/src/Terms.php
@@ -100,7 +100,7 @@ class Terms extends AbstractObjects {
 		global $wpdb;
 
 		$batch_size = $this->getBatchSyze();
-		$offset     = absint( ( $this->step * $batch_size ) - $batch_size );
+		$offset     = ( $this->step * $batch_size ) - $batch_size;
 		$trids      = $wpdb->get_col(
 			sprintf(
 				"SELECT DISTINCT wpml.trid
@@ -111,8 +111,8 @@ class Terms extends AbstractObjects {
 				WHERE tt.taxonomy IN ( '%s' )
 				LIMIT %d, %d",
 				implode( "', '", esc_sql( $this->getTranslatedTaxonomies() ) ),
-				$offset,
-				$batch_size
+				absint( $offset ),
+				absint( $batch_size )
 			)
 		);
 


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/2482.
Fixes #21 

ACFML is WPML's [compat' plugin](https://wpml.org/documentation/related-projects/translate-sites-built-with-acf/) for ACF.

This PR brings compatibility with WPML's "Translations" selector (none / copy / copy once / translate) by changing ACFML's data format into PLL's format.
ACFML adds a `wpml_cf_preferences` key to the fields, with `0` (none), `1` (copy), `2` (translate), or `3` (copy once) as value.

The new class `ACFFields` acts like the other classes, like `Posts` etc, and allows to translate ACFML's data into PLL's.
Since the fields' data is stored in post's `post_content` column as serialized array, `SELECT` queries made with `wpdb` look for entries containing `"wpml_cf_preferences"`. At the end of each batch, a single `wpdb` query updates the data for the whole batch. This is why the batch size has been reduced by 100, so the query doesn't grow too much.
ACFML's data is not removed.

Note:
ACFML adds a `acfml_field_group_mode` data to field groups. Values can be `translation` (Same fields across languages), `localization` (Different fields across languages), or `advanced` ([Expert](https://wpml.org/documentation/related-projects/translate-sites-built-with-acf/expert-translation-option/)). This setting allows to set the "Translations" selector of each field automatically. For example with "Same fields across languages", a `number` field is set to "Copy", but it will be set to "Copy once" if the group is set to "Different fields across languages". See [this post](https://wpml.org/documentation/related-projects/translate-sites-built-with-acf/recommended-custom-fields-translation-preferences-for-acf-and-wpml/) for the details.