### PR TITLE
Remove duplicate code to set translations in mass

### DIFF
--- a/src/AbstractObjects.php
+++ b/src/AbstractObjects.php
@@ -7,6 +7,8 @@
 
 namespace WP_Syntex\WPML_To_Polylang;
 
+use PLL_Translated_Object;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -112,77 +114,20 @@ abstract class AbstractObjects extends AbstractSteppable {
 	 * @return void
 	 */
 	protected function processTranslations( $translations ) {
-		global $wpdb;
+		$translated_object = false;
 
-		$terms = [];
-
-		foreach ( array_keys( $translations ) as $name ) {
-			$terms[] = $wpdb->prepare( '(%s, %s)', $name, $name );
-		}
-
-		$terms = array_unique( $terms );
-
-		// Insert terms.
-		if ( ! empty( $terms ) ) {
-			$wpdb->query( "INSERT INTO $wpdb->terms (slug, name) VALUES " . implode( ',', $terms ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-		}
-
-		// Get all terms with their term_id.
-		$terms = $wpdb->get_results(
-			sprintf(
-				"SELECT term_id, slug FROM $wpdb->terms WHERE slug IN ( '%s' )",
-				implode( "', '", esc_sql( array_keys( $translations ) ) )
-			)
-		);
-
-		$tts = [];
-
-		foreach ( $terms as $term ) {
-			$tts[] = $wpdb->prepare(
-				'(%d, %s, %s, %d)',
-				$term->term_id,
-				$this->getTranslationTaxonomy(),
-				serialize( $translations[ $term->slug ] ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
-				count( $translations[ $term->slug ] )
-			);
-		}
-
-		$tts = array_unique( $tts );
-
-		// Insert term taxonomy part of terms.
-		if ( ! empty( $tts ) ) {
-			$wpdb->query( "INSERT INTO $wpdb->term_taxonomy (term_id, taxonomy, description, count) VALUES " . implode( ',', $tts ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-		}
-
-		unset( $terms, $tts ); // Free some memory.
-
-		// Get all terms with their term taxonomy id.
-		$terms = $wpdb->get_results(
-			sprintf(
-				"SELECT tt.term_taxonomy_id, t.slug FROM $wpdb->terms AS t
-				INNER JOIN $wpdb->term_taxonomy AS tt ON t.term_id = tt.term_id
-				WHERE tt.taxonomy = '%s'
-				AND t.slug IN ( '%s' )",
-				esc_sql( $this->getTranslationTaxonomy() ),
-				implode( "', '", esc_sql( array_keys( $translations ) ) )
-			)
-		);
-
-		$trs = [];
-
-		if ( is_array( $terms ) ) {
-			foreach ( $terms as $term ) {
-				foreach ( $translations[ $term->slug ] as $object_id ) {
-					$trs[] = sprintf( '(%d, %d)', (int) $object_id, (int) $term->term_taxonomy_id );
-				}
+		foreach ( PLL()->model->translatable_objects as $translatable_object ) {
+			if ( $translatable_object->get_tax_translations() === $this->getTranslationTaxonomy() ) {
+				$translated_object = $translatable_object;
+				break;
 			}
 		}
 
-		$trs = array_unique( $trs );
-
-		// Insert term relationships.
-		if ( ! empty( $trs ) ) {
-			$wpdb->query( "INSERT INTO $wpdb->term_relationships (object_id, term_taxonomy_id) VALUES " . implode( ',', $trs ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		if ( ! $translated_object instanceof PLL_Translated_Object ) {
+			// Uh?
+			return;
 		}
+
+		$translated_object->set_translation_in_mass( $translations );
 	}
 }

--- a/src/AbstractObjects.php
+++ b/src/AbstractObjects.php
@@ -17,6 +17,15 @@ defined( 'ABSPATH' ) || exit;
  * @since 0.5
  */
 abstract class AbstractObjects extends AbstractSteppable {
+	/**
+	 * Returns the type of the object (post, term...).
+	 * Must match `PLL_Translatable_Object::get_type()`.
+	 *
+	 * @since 0.6
+	 *
+	 * @return string
+	 */
+	abstract protected function getObjectType();
 
 	/**
 	 * Gets the languages term taxonomy ids related to this object type.
@@ -114,14 +123,7 @@ abstract class AbstractObjects extends AbstractSteppable {
 	 * @return void
 	 */
 	protected function processTranslations( $translations ) {
-		$translated_object = false;
-
-		foreach ( PLL()->model->translatable_objects as $translatable_object ) {
-			if ( $translatable_object->get_tax_translations() === $this->getTranslationTaxonomy() ) {
-				$translated_object = $translatable_object;
-				break;
-			}
-		}
+		$translated_object = PLL()->model->translatable_objects->get( $this->getObjectType() );
 
 		if ( ! $translated_object instanceof PLL_Translated_Object ) {
 			// Uh?

--- a/src/AbstractObjects.php
+++ b/src/AbstractObjects.php
@@ -21,7 +21,7 @@ abstract class AbstractObjects extends AbstractSteppable {
 	 * Returns the type of the object (post, term...).
 	 * Must match `PLL_Translatable_Object::get_type()`.
 	 *
-	 * @since 0.6
+	 * @since 0.7
 	 *
 	 * @return string
 	 */

--- a/src/Posts.php
+++ b/src/Posts.php
@@ -15,6 +15,16 @@ defined( 'ABSPATH' ) || exit;
  * @since 0.5
  */
 class Posts extends AbstractObjects {
+	/**
+	 * Returns the type of the object.
+	 *
+	 * @since 0.6
+	 *
+	 * @return string
+	 */
+	protected function getObjectType() {
+		return 'post';
+	}
 
 	/**
 	 * Returns the action name.

--- a/src/Posts.php
+++ b/src/Posts.php
@@ -18,7 +18,7 @@ class Posts extends AbstractObjects {
 	/**
 	 * Returns the type of the object.
 	 *
-	 * @since 0.6
+	 * @since 0.7
 	 *
 	 * @return string
 	 */

--- a/src/Posts.php
+++ b/src/Posts.php
@@ -138,7 +138,7 @@ class Posts extends AbstractObjects {
 		// Remove empty ids and group translations by translation group.
 		foreach ( $results as $t ) {
 			if ( ! empty( $t->trid ) && ! empty( $t->language_code ) && ! empty( $t->id ) ) {
-				$translations[ 'pll_wpml_' . $t->trid ][ $t->language_code ] = (int) $t->id;
+				$translations[ 'wpml_' . $t->trid ][ $t->language_code ] = (int) $t->id;
 			}
 		}
 

--- a/src/Posts.php
+++ b/src/Posts.php
@@ -138,7 +138,7 @@ class Posts extends AbstractObjects {
 		// Remove empty ids and group translations by translation group.
 		foreach ( $results as $t ) {
 			if ( ! empty( $t->trid ) && ! empty( $t->language_code ) && ! empty( $t->id ) ) {
-				$translations[ 'wpml_' . $t->trid ][ $t->language_code ] = (int) $t->id;
+				$translations[ 'pll_wpml_' . $t->trid ][ $t->language_code ] = (int) $t->id;
 			}
 		}
 

--- a/src/Terms.php
+++ b/src/Terms.php
@@ -147,7 +147,7 @@ class Terms extends AbstractObjects {
 		// Remove empty ids and group translations by translation group.
 		foreach ( $results as $t ) {
 			if ( ! empty( $t->trid ) && ! empty( $t->language_code ) && ! empty( $t->id ) ) {
-				$translations[ 'wpml_' . $t->trid ][ $t->language_code ] = (int) $t->id;
+				$translations[ 'pll_wpml_' . $t->trid ][ $t->language_code ] = (int) $t->id;
 			}
 		}
 

--- a/src/Terms.php
+++ b/src/Terms.php
@@ -18,7 +18,7 @@ class Terms extends AbstractObjects {
 	/**
 	 * Returns the type of the object.
 	 *
-	 * @since 0.6
+	 * @since 0.7
 	 *
 	 * @return string
 	 */

--- a/src/Terms.php
+++ b/src/Terms.php
@@ -15,6 +15,16 @@ defined( 'ABSPATH' ) || exit;
  * @since 0.5
  */
 class Terms extends AbstractObjects {
+	/**
+	 * Returns the type of the object.
+	 *
+	 * @since 0.6
+	 *
+	 * @return string
+	 */
+	protected function getObjectType() {
+		return 'term';
+	}
 
 	/**
 	 * Returns the action name.

--- a/src/Terms.php
+++ b/src/Terms.php
@@ -147,7 +147,7 @@ class Terms extends AbstractObjects {
 		// Remove empty ids and group translations by translation group.
 		foreach ( $results as $t ) {
 			if ( ! empty( $t->trid ) && ! empty( $t->language_code ) && ! empty( $t->id ) ) {
-				$translations[ 'pll_wpml_' . $t->trid ][ $t->language_code ] = (int) $t->id;
+				$translations[ 'wpml_' . $t->trid ][ $t->language_code ] = (int) $t->id;
 			}
 		}
 


### PR DESCRIPTION
Fixes https://github.com/polylang/polylang-pro/issues/2491.

Use `PLL_Translated_Object::set_translation_in_mass()` to set translations in mass, instead of duplicating code.

The custom term names can be kept with https://github.com/polylang/polylang/pull/1664.

Note: `PLL()->model->translatable_objects` is available since PLL 3.4, which is already the minimum version required by this plugin.