### PR TITLE
Use the new Languages class instead of PLL_Admin_Model

### DIFF
--- a/src/AbstractObjects.php
+++ b/src/AbstractObjects.php
@@ -109,7 +109,7 @@ abstract class AbstractObjects extends AbstractSteppable {
 			$wpdb->query( "INSERT INTO {$wpdb->term_relationships} (object_id, term_taxonomy_id) VALUES " . implode( ',', $relations ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		}
 
-		foreach ( PLL()->model->get_languages_list() as $lang ) {
+		foreach ( PLL()->model->languages->get_list() as $lang ) {
 			$lang->update_count();
 		}
 	}

--- a/src/Languages.php
+++ b/src/Languages.php
@@ -59,7 +59,7 @@ class Languages extends AbstractAction {
 			$lang['rtl']  = isset( $predefinedLanguages[ $lang['locale'] ]['dir'] ) && 'rtl' === $predefinedLanguages[ $lang['locale'] ]['dir'] ? 1 : 0;
 			$lang['flag'] = isset( $predefinedLanguages[ $lang['locale'] ]['flag'] ) ? $predefinedLanguages[ $lang['locale'] ]['flag'] : '';
 
-			PLL()->model->add_language( $lang );
+			PLL()->model->languages->add( $lang );
 		}
 
 		$this->cleanup();

--- a/src/Languages.php
+++ b/src/Languages.php
@@ -92,7 +92,7 @@ class Languages extends AbstractAction {
 			wp_delete_object_term_relationships( (int) $defaultCat, 'term_language' );
 		}
 
-		PLL()->model->clean_languages_cache(); // Update the languages list.
+		PLL()->model->languages->clean_cache(); // Update the languages list.
 	}
 
 	/**

--- a/src/Page.php
+++ b/src/Page.php
@@ -181,7 +181,7 @@ class Page {
 				$checks[] = __( 'Your version of Polylang is too old. Please update.', 'wpml-to-polylang' );
 			}
 
-			if ( PLL()->model->get_languages_list() ) {
+			if ( PLL()->model->languages->get_list() ) {
 				$checks[] = __( 'Polylang has already been installed on this website. Impossible to run the import.', 'wpml-to-polylang' );
 			}
 		}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -16,17 +16,6 @@ defined( 'ABSPATH' ) || exit;
  */
 class Plugin {
 	/**
-	 * Uses PLL_Admin_Model to be able to create languages.
-	 *
-	 * @since 0.5
-	 *
-	 * @return string
-	 */
-	public function filterModel() {
-		return 'PLL_Admin_Model';
-	}
-
-	/**
 	 * Initializes the plugin.
 	 *
 	 * @since 0.5
@@ -34,8 +23,6 @@ class Plugin {
 	 * @return void
 	 */
 	public function init() {
-		add_filter( 'pll_model', [ $this, 'filterModel' ] );
-
 		$actions = [
 			new Languages(),
 			new Posts(),

--- a/src/Posts.php
+++ b/src/Posts.php
@@ -58,7 +58,7 @@ class Posts extends AbstractObjects {
 	protected function getLanguageTermTaxonomyIds() {
 		$languages = [];
 
-		foreach ( PLL()->model->get_languages_list() as $lang ) {
+		foreach ( PLL()->model->languages->get_list() as $lang ) {
 			$languages[ $lang->slug ] = $lang->get_tax_prop( 'language', 'term_taxonomy_id' );
 		}
 

--- a/src/Strings.php
+++ b/src/Strings.php
@@ -53,7 +53,7 @@ class Strings extends AbstractSteppable {
 		}
 
 		foreach ( $stringTranslations as $lang => $strings ) {
-			$language = PLL()->model->get_language( $lang );
+			$language = PLL()->model->languages->get( $lang );
 
 			if ( empty( $language ) ) {
 				continue;

--- a/src/Terms.php
+++ b/src/Terms.php
@@ -58,7 +58,7 @@ class Terms extends AbstractObjects {
 	protected function getLanguageTermTaxonomyIds() {
 		$languages = [];
 
-		foreach ( PLL()->model->get_languages_list() as $lang ) {
+		foreach ( PLL()->model->languages->get_list() as $lang ) {
 			$languages[ $lang->slug ] = $lang->get_tax_prop( 'term_language', 'term_taxonomy_id' );
 		}
 

--- a/wpml-to-polylang.php
+++ b/wpml-to-polylang.php
@@ -23,7 +23,7 @@
  * License URI:          https://www.gnu.org/licenses/gpl-3.0.txt
  *
  * Copyright 2013-2020 Frédéric Demarle
- * Copyright 2021-2023 WP SYNTEX
+ * Copyright 2021-2026 WP SYNTEX
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -45,7 +45,7 @@ defined( 'ABSPATH' ) || exit;
 
 define( 'WPML_TO_POLYLANG_VERSION', '0.6' );
 define( 'WPML_TO_POLYLANG_MIN_WP_VERSION', '5.8' );
-define( 'WPML_TO_POLYLANG_MIN_PLL_VERSION', '3.4' );
+define( 'WPML_TO_POLYLANG_MIN_PLL_VERSION', '3.7' );
 
 if ( ! defined( 'WPML_TO_POLYLANG_QUERY_BATCH_SIZE' ) ) {
 	define( 'WPML_TO_POLYLANG_QUERY_BATCH_SIZE', 5000 ); // Limits the size of database queries.


### PR DESCRIPTION
This will allow to deprecate the `PLL_Admin_Model` class and the `pll_model` filter which shouldn't be useful anymore.
This requires to use Polylang 3.7 or higher.