### PR TITLE
WPML → Polylang: full migration toolkit (strings, ACF options, menus, unified UI)

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1,78 +1,65 @@
-jQuery(
-	function( $ ) {
-		/**
-		 * Batch processing to migrate WPML data to Polylang.
-		 */
-		window.WPMLToPolylang = {
-			/**
-			 * Disables the submit button and fires the batch process.
-			 */
-			init: function() {
-				const self = this;
+jQuery( function ( $ ) {
+	/**
+	 * WPML → Polylang migration toolkit.
+	 *
+	 * Each form on the page is independent: it has its own submit button and its
+	 * own status div (identified by the form's data-tool attribute).
+	 */
 
-				$( 'form' ).on(
-					'submit',
-					function( event ) {
-						event.preventDefault();
+	$( '.wpml-pll-form' ).each( function () {
+		var form   = $( this );
+		var toolId = form.data( 'tool' );
+		var status = $( '#wpml-status-' + toolId );
+		var btn    = form.find( 'button[type="submit"]' );
 
-						const form   = $( this );
-						const data   = self.formToArray( form );
-						const submit = form.find( 'input[type="submit"]' );
+		form.on( 'submit', function ( e ) {
+			e.preventDefault();
 
-						submit.attr( 'disabled', true );
-						self.process( data, self );
-					}
-				);
+			btn.prop( 'disabled', true ).text( btn.text().trim() );
+			status.removeClass( 'is-done' ).text( '' );
+
+			var data = serialiseForm( form );
+			sendRequest( data, status, btn );
+		} );
+	} );
+
+	function serialiseForm( form ) {
+		var out = {};
+		$.each( form.serializeArray(), function ( _, field ) {
+			out[ field.name ] = field.value;
+		} );
+		return out;
+	}
+
+	function sendRequest( data, status, btn ) {
+		$.post( {
+			url:      ajaxurl,
+			data:     data,
+			dataType: 'json',
+			success: function ( response ) {
+				handleResponse( response, data, status, btn );
 			},
-
-			/**
-			 * Transforms submitted form in a convenient array of data.
-			 */
-			formToArray: function( form ) {
-				var ret = {};
-
-				form = form.serializeArray();
-				for ( i = 0; i < form.length; i++ ) {
-					ret[ form[i].name ] = form[i].value;
-				}
-
-				return ret;
-			},
-
-			/**
-			 * Sends the ajax request.
-			 */
-			process: function( data, self ) {
-				$.post(
-					{
-						url: ajaxurl,
-						data: data,
-						dataType: 'json',
-						success: function ( response ) {
-							self.success( response, data, self );
-						}
-					}
-				);
-			},
-
-			/**
-			 * Processes the ajax response.
-			 */
-			success: function( response, data, self ) {
-				$( '#wpml-importer-status' ).text( response.message );
-
-				if ( ! response.done ) {
-					data['action'] = response.action;
-					data['step']   = response.step;
-					self.process( data, self );
-				}
+			error: function () {
+				status.text( 'An unexpected error occurred. Please try again.' );
+				btn.prop( 'disabled', false );
 			}
-		}
+		} );
 	}
-);
 
-jQuery(
-	function( $ ) {
-		window.WPMLToPolylang && window.WPMLToPolylang.init();
+	function handleResponse( response, data, status, btn ) {
+		if ( response.done ) {
+			status.addClass( 'is-done' ).text( 'Done!' );
+			btn.prop( 'disabled', false );
+			return;
+		}
+
+		if ( response.message ) {
+			status.text( response.message );
+		}
+
+		// Chain to the next step.
+		data['action'] = response.action;
+		data['step']   = response.step;
+		sendRequest( data, status, btn );
 	}
-);
+} );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "wpml-to-polylang",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/src/AcfOptions.php
+++ b/src/AcfOptions.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * PHP version 5.6
+ *
+ * @package wpml-to-polylang
+ */
+
+namespace WP_Syntex\WPML_To_Polylang;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Migrates ACF options-page values that were stored with the Polylang language SLUG
+ * as a prefix (e.g. `options_fr_my_field`) into the LOCALE-prefix format expected by
+ * "ACF Options For Polylang" v2.0+ (e.g. `options_fr_FR_my_field`).
+ *
+ * Background:
+ * Older versions of the "ACF Options For Polylang" plugin appended the Polylang
+ * language SLUG to the ACF post_id (options_fr, options_de, …). Version 2.0 switched
+ * to the LOCALE (options_fr_FR, options_de_DE, …) which is also what ACF's own
+ * Polylang integration uses for the built-in "options" page.
+ *
+ * This class reads every `options_{slug}_*` and `_options_{slug}_*` row in wp_options
+ * and writes a copy under `options_{locale}_*` / `_options_{locale}_*`.
+ * Existing locale-format entries are never overwritten.
+ *
+ * @since 0.7
+ */
+class AcfOptions extends AbstractAction {
+
+	/**
+	 * Returns the action name.
+	 *
+	 * @since 0.7
+	 *
+	 * @return string
+	 */
+	public function getName() {
+		return 'process_acf_options';
+	}
+
+	/**
+	 * Returns the processing message.
+	 *
+	 * @since 0.7
+	 *
+	 * @return string
+	 */
+	protected function getMessage() {
+		return esc_html__( 'Migrating ACF options page translations', 'wpml-to-polylang' );
+	}
+
+	/**
+	 * Copies ACF options from slug-prefix format to locale-prefix format.
+	 *
+	 * @since 0.7
+	 *
+	 * @return void
+	 */
+	protected function handle() {
+		global $wpdb;
+
+		$languages = PLL()->model->get_languages_list();
+
+		if ( empty( $languages ) ) {
+			return;
+		}
+
+		foreach ( $languages as $language ) {
+			if ( $language->is_default ) {
+				continue;
+			}
+
+			$slug   = $language->slug;
+			$locale = $language->locale;
+
+			if ( $slug === $locale ) {
+				// Nothing to migrate when slug and locale are identical.
+				continue;
+			}
+
+			// Fetch all options stored with the slug-prefix format (values + field refs).
+			$like_value = $wpdb->esc_like( "options_{$slug}_" ) . '%';
+			$like_ref   = $wpdb->esc_like( "_options_{$slug}_" ) . '%';
+
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- values are esc_like-escaped above.
+			$rows = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT option_name, option_value, autoload
+					 FROM {$wpdb->options}
+					 WHERE option_name LIKE %s OR option_name LIKE %s",
+					$like_value,
+					$like_ref
+				)
+			);
+
+			if ( empty( $rows ) ) {
+				continue;
+			}
+
+			foreach ( $rows as $row ) {
+				$old_name = $row->option_name;
+
+				// Replace the first occurrence of _{slug}_ with _{locale}_.
+				$new_name = $this->renameOption( $old_name, $slug, $locale );
+
+				if ( null === $new_name || $new_name === $old_name ) {
+					continue;
+				}
+
+				// Never overwrite an existing locale-format entry.
+				if ( false !== get_option( $new_name ) ) {
+					continue;
+				}
+
+				add_option( $new_name, maybe_unserialize( $row->option_value ), '', 'no' );
+			}
+		}
+	}
+
+	/**
+	 * Renames an option key from slug-prefix to locale-prefix format.
+	 *
+	 * Handles both the value entry (`options_{slug}_{rest}`) and the ACF field
+	 * reference entry (`_options_{slug}_{rest}`).
+	 *
+	 * @since 0.7
+	 *
+	 * @param string $option_name Original option name.
+	 * @param string $slug        Polylang language slug (e.g. 'fr').
+	 * @param string $locale      Polylang language locale (e.g. 'fr_FR').
+	 * @return string|null New option name, or null if no substitution was needed.
+	 */
+	protected function renameOption( $option_name, $slug, $locale ) {
+		foreach ( [ "options_{$slug}_", "_options_{$slug}_" ] as $slug_prefix ) {
+			if ( 0 === strpos( $option_name, $slug_prefix ) ) {
+				$locale_prefix = str_replace( "_{$slug}_", "_{$locale}_", $slug_prefix );
+				return $locale_prefix . substr( $option_name, strlen( $slug_prefix ) );
+			}
+		}
+
+		return null;
+	}
+}

--- a/src/NavMenuContent.php
+++ b/src/NavMenuContent.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * PHP version 5.6
+ *
+ * @package wpml-to-polylang
+ */
+
+namespace WP_Syntex\WPML_To_Polylang;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Rewrites hardcoded nav_menu IDs inside post content for translated posts.
+ *
+ * Problem: WPBakery Page Builder stores menus by term ID, e.g.
+ *   [vc_wp_custommenu nav_menu="56"]
+ * With WPML active, those IDs were resolved to the current language's menu at
+ * render time. Polylang does NOT do this unless menus are explicitly assigned
+ * a language and linked as translations.
+ *
+ * Solution: Update the post_content of every non-default-language post so
+ * that each `nav_menu="X"` attribute is replaced with the menu ID that WPML
+ * recorded as the translation of menu X for that language.
+ *
+ * This is a one-step, non-batched action because the number of affected posts
+ * is typically very small (e.g. one global-section post per language).
+ *
+ * @since 1.0
+ */
+class NavMenuContent extends AbstractAction {
+
+	/**
+	 * Returns the action name.
+	 *
+	 * @since 1.0
+	 *
+	 * @return string
+	 */
+	public function getName() {
+		return 'process_nav_menu_content';
+	}
+
+	/**
+	 * Returns the processing message.
+	 *
+	 * @since 1.0
+	 *
+	 * @return string
+	 */
+	protected function getMessage() {
+		return esc_html__( 'Fixing menu references in translated post content', 'wpml-to-polylang' );
+	}
+
+	/**
+	 * Rewrites nav_menu IDs in all translated posts.
+	 *
+	 * @since 1.0
+	 *
+	 * @return void
+	 */
+	protected function handle() {
+		global $wpdb;
+
+		// Build a map: source_menu_id → [ lang => translated_menu_id ]
+		$menuMap = $this->buildMenuMap();
+		if ( empty( $menuMap ) ) {
+			return;
+		}
+
+		$defaultLang = pll_default_language();
+
+		// Find all translated (non-default-language) posts that contain nav_menu= attribute.
+		$posts = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT p.ID, p.post_content, lang.slug AS lang
+				FROM {$wpdb->posts} p
+				JOIN {$wpdb->term_relationships} tr ON tr.object_id = p.ID
+				JOIN {$wpdb->term_taxonomy} tt
+					ON tt.term_taxonomy_id = tr.term_taxonomy_id AND tt.taxonomy = 'language'
+				JOIN {$wpdb->terms} lang ON lang.term_id = tt.term_id
+				WHERE p.post_status NOT IN ('trash','auto-draft')
+				  AND p.post_content LIKE %s
+				  AND lang.slug != %s",
+				'%nav_menu="%',
+				$defaultLang
+			)
+		);
+
+		if ( empty( $posts ) ) {
+			return;
+		}
+
+		foreach ( $posts as $post ) {
+			$newContent = $this->rewriteMenuIds( $post->post_content, $post->lang, $menuMap );
+
+			if ( $newContent === $post->post_content ) {
+				continue;
+			}
+
+			$wpdb->update(
+				$wpdb->posts,
+				[ 'post_content' => $newContent ],
+				[ 'ID' => $post->ID ],
+				[ '%s' ],
+				[ '%d' ]
+			);
+
+			clean_post_cache( $post->ID );
+		}
+	}
+
+	/**
+	 * Replaces every `nav_menu="X"` in $content with the translated menu ID
+	 * for $lang, falling back to the original ID when no translation exists.
+	 *
+	 * @param string   $content Post content.
+	 * @param string   $lang    Language slug (e.g. 'fr').
+	 * @param int[][]  $menuMap Source-menu-id → [ lang => translated_id ].
+	 * @return string
+	 */
+	private function rewriteMenuIds( $content, $lang, array $menuMap ) {
+		return preg_replace_callback(
+			'/nav_menu="(\d+)"/',
+			function ( $matches ) use ( $lang, $menuMap ) {
+				$sourceId = (int) $matches[1];
+				if ( isset( $menuMap[ $sourceId ][ $lang ] ) ) {
+					return 'nav_menu="' . $menuMap[ $sourceId ][ $lang ] . '"';
+				}
+				return $matches[0];
+			},
+			$content
+		);
+	}
+
+	/**
+	 * Builds a map of source-language menu IDs to their per-language translations.
+	 *
+	 * Returns: [ sourceMenuId => [ langSlug => translatedMenuId, … ], … ]
+	 *
+	 * @return int[][]
+	 */
+	private function buildMenuMap() {
+		global $wpdb;
+
+		$defaultLang = pll_default_language();
+
+		$rows = $wpdb->get_results(
+			"SELECT DISTINCT t.term_id AS menu_id, it.language_code AS lang, it.trid
+			FROM {$wpdb->terms} t
+			JOIN {$wpdb->term_taxonomy} tt ON tt.term_id = t.term_id AND tt.taxonomy = 'nav_menu'
+			JOIN {$wpdb->prefix}icl_translations it
+				ON it.element_id = tt.term_taxonomy_id
+				AND it.element_type = 'tax_nav_menu'"
+		);
+
+		if ( empty( $rows ) ) {
+			return [];
+		}
+
+		// Group by trid so we can identify the source-language menu in each group.
+		$byTrid = [];
+		foreach ( $rows as $row ) {
+			$byTrid[ $row->trid ][ $row->lang ] = (int) $row->menu_id;
+		}
+
+		$map = [];
+		foreach ( $byTrid as $translations ) {
+			if ( empty( $translations[ $defaultLang ] ) ) {
+				continue; // No source-language menu in this group.
+			}
+			$sourceId = $translations[ $defaultLang ];
+			foreach ( $translations as $lang => $menuId ) {
+				if ( $lang !== $defaultLang ) {
+					$map[ $sourceId ][ $lang ] = $menuId;
+				}
+			}
+		}
+
+		return $map;
+	}
+}

--- a/src/Page.php
+++ b/src/Page.php
@@ -10,36 +10,57 @@ namespace WP_Syntex\WPML_To_Polylang;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Main plugin class.
+ * Single unified admin page for the WPML → Polylang migration toolkit.
+ *
+ * Renders the Full Migration card (one-time) plus individual cards for every
+ * additional standalone tool (repeatable). All tools share a single menu entry
+ * under Tools and the same JS bundle.
  *
  * @since 0.5
  */
 class Page {
 
 	/**
-	 * Action to execute first.
-	 *
-	 * @since 0.5
+	 * AJAX action name that kicks off the full migration chain.
 	 *
 	 * @var string
 	 */
 	protected $action;
 
 	/**
+	 * Standalone tool descriptors added via addTool().
+	 *
+	 * Each entry: [ 'id', 'action', 'title', 'description', 'button' ]
+	 *
+	 * @var array[]
+	 */
+	private $tools = [];
+
+	/**
 	 * Constructor.
 	 *
-	 * @since 0.5
-	 *
-	 * @param string $action Action to execute first.
+	 * @param string $action AJAX action name for the first step of the full migration.
 	 */
 	public function __construct( $action ) {
 		$this->action = $action;
 	}
 
 	/**
-	 * Setups hooks.
+	 * Registers a standalone (repeatable) tool card on the page.
 	 *
-	 * @since 0.5
+	 * @param string $id          Unique slug used for HTML IDs (e.g. 'strings').
+	 * @param string $action      AJAX action name.
+	 * @param string $title       Card heading.
+	 * @param string $description Short paragraph describing what the tool does.
+	 * @param string $button      Submit button label.
+	 * @return void
+	 */
+	public function addTool( $id, $action, $title, $description, $button ) {
+		$this->tools[] = compact( 'id', 'action', 'title', 'description', 'button' );
+	}
+
+	/**
+	 * Registers WordPress hooks.
 	 *
 	 * @return void
 	 */
@@ -49,15 +70,13 @@ class Page {
 	}
 
 	/**
-	 * Adds the link to the languages panel in the WordPress admin menu.
-	 *
-	 * @since 0.5
+	 * Adds the single Tools sub-menu entry.
 	 *
 	 * @return void
 	 */
 	public function addMenus() {
-		load_plugin_textdomain( 'wpml-to-polylang' ); // Plugin i18n.
-		$title = __( 'WPML importer', 'wpml-to-polylang' );
+		load_plugin_textdomain( 'wpml-to-polylang' );
+		$title = __( 'WPML to Polylang', 'wpml-to-polylang' );
 		add_submenu_page(
 			'tools.php',
 			$title,
@@ -69,9 +88,7 @@ class Page {
 	}
 
 	/**
-	 * Enqueues scripts.
-	 *
-	 * @since 0.5
+	 * Enqueues the JS bundle only on this page.
 	 *
 	 * @return void
 	 */
@@ -81,82 +98,304 @@ class Page {
 			return;
 		}
 
-		wp_enqueue_script( 'wpml-importer', plugins_url( 'js/index.js', __DIR__ ), [ 'jquery', 'wp-ajax-response' ], WPML_TO_POLYLANG_VERSION, true );
+		wp_enqueue_script(
+			'wpml-importer',
+			plugins_url( 'js/index.js', __DIR__ ),
+			[ 'jquery', 'wp-ajax-response' ],
+			WPML_TO_POLYLANG_VERSION,
+			true
+		);
 	}
 
 	/**
-	 * Displays the page.
-	 *
-	 * @since 0.5
+	 * Renders the full page.
 	 *
 	 * @return void
 	 */
 	public function display() {
-		$errors = $this->getErrors();
 		?>
-		<div class="wrap">
-			<h2><?php esc_html_e( 'WPML Importer', 'wpml-to-polylang' ); ?></h2>
-			<?php
-			if ( empty( $errors ) ) {
-				$this->displayForm();
-			} else {
-				foreach ( $errors as $error ) {
-					$this->displayNotice( $error );
-				}
-			}
-			?>
-		</div>
-		<?php
+		<div class="wrap wpml-pll-wrap">
+			<?php $this->renderStyles(); ?>
 
-	}
-
-	/**
-	 * Displays the form.
-	 *
-	 * @since 0.5
-	 *
-	 * @return void
-	 */
-	protected function displayForm() {
-		?>
-		<div class="form-wrap">
-			<p><?php esc_html_e( 'Your website is ready to import WPML data to Polylang.', 'wpml-to-polylang' ); ?></p>
-			<form id="batch" method="post">
-				<input type="hidden" name="action" value="<?php echo esc_attr( $this->action ); ?>">
-				<?php wp_nonce_field( 'wpml-importer', '_wpnonce_wpml-importer' ); ?>
-				<?php submit_button( __( 'Import', 'wpml-to-polylang' ) ); ?>
-				<div id="wpml-importer-status"></div>
-			</form>
-		</div>
-		<?php
-	}
-
-	/**
-	 * Displays error notices.
-	 *
-	 * @since 0.5
-	 *
-	 * @param string $error Error message.
-	 * @return void
-	 */
-	protected function displayNotice( $error ) {
-		?>
-		<div class="notice notice-error">
-			<p>
-				<?php echo esc_html( $error ); ?>
+			<h1 class="wpml-pll-heading">
+				<?php esc_html_e( 'WPML → Polylang', 'wpml-to-polylang' ); ?>
+			</h1>
+			<p class="wpml-pll-subtitle">
+				<?php esc_html_e( 'Migration toolkit — run the full import once, then use the individual tools below as needed.', 'wpml-to-polylang' ); ?>
 			</p>
+
+			<?php $this->renderMainCard(); ?>
+
+			<?php if ( ! empty( $this->tools ) ) : ?>
+				<h2 class="wpml-pll-section-title">
+					<?php esc_html_e( 'Additional Tools', 'wpml-to-polylang' ); ?>
+				</h2>
+				<p class="wpml-pll-section-desc">
+					<?php esc_html_e( 'These can be run independently at any time after the initial migration.', 'wpml-to-polylang' ); ?>
+				</p>
+				<div class="wpml-pll-tools-grid">
+					<?php foreach ( $this->tools as $tool ) : ?>
+						<?php $this->renderToolCard( $tool ); ?>
+					<?php endforeach; ?>
+				</div>
+			<?php endif; ?>
+		</div>
+		<?php
+	}
+
+	// -------------------------------------------------------------------------
+	// Private rendering helpers
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Renders the primary Full Migration card.
+	 *
+	 * @return void
+	 */
+	private function renderMainCard() {
+		$errors = $this->getMainErrors();
+		?>
+		<div class="wpml-pll-card wpml-pll-card--primary">
+			<div class="wpml-pll-card-header">
+				<span class="wpml-pll-card-icon dashicons dashicons-migrate"></span>
+				<div>
+					<h2 class="wpml-pll-card-title">
+						<?php esc_html_e( 'Full Migration', 'wpml-to-polylang' ); ?>
+					</h2>
+					<p class="wpml-pll-card-desc">
+						<?php esc_html_e( 'Runs the complete pipeline: languages, posts, terms, menus, strings, WordPress options, and ACF fields.', 'wpml-to-polylang' ); ?>
+					</p>
+				</div>
+				<span class="wpml-pll-badge wpml-pll-badge--once">
+					<?php esc_html_e( 'One-time', 'wpml-to-polylang' ); ?>
+				</span>
+			</div>
+
+			<?php if ( ! empty( $errors ) ) : ?>
+				<div class="wpml-pll-notices">
+					<?php foreach ( $errors as $error ) : ?>
+						<div class="notice notice-error inline"><p><?php echo esc_html( $error ); ?></p></div>
+					<?php endforeach; ?>
+				</div>
+			<?php else : ?>
+				<form class="wpml-pll-form" data-tool="main">
+					<input type="hidden" name="action" value="<?php echo esc_attr( $this->action ); ?>">
+					<?php wp_nonce_field( 'wpml-importer', '_wpnonce_wpml-importer' ); ?>
+					<button type="submit" class="button button-primary button-large">
+						<?php esc_html_e( 'Run Full Migration', 'wpml-to-polylang' ); ?>
+					</button>
+					<div class="wpml-pll-status" id="wpml-status-main"></div>
+				</form>
+			<?php endif; ?>
 		</div>
 		<?php
 	}
 
 	/**
-	 * Performs checks before the import is run.
+	 * Renders a standalone tool card.
 	 *
-	 * @since 0.5
+	 * @param array $tool Tool descriptor array.
+	 * @return void
+	 */
+	private function renderToolCard( array $tool ) {
+		$errors = $this->getToolErrors( $tool['id'] );
+		?>
+		<div class="wpml-pll-card">
+			<div class="wpml-pll-card-header">
+				<div>
+					<h3 class="wpml-pll-card-title"><?php echo esc_html( $tool['title'] ); ?></h3>
+					<p class="wpml-pll-card-desc"><?php echo esc_html( $tool['description'] ); ?></p>
+				</div>
+				<span class="wpml-pll-badge wpml-pll-badge--repeatable">
+					<?php esc_html_e( 'Repeatable', 'wpml-to-polylang' ); ?>
+				</span>
+			</div>
+
+			<?php if ( ! empty( $errors ) ) : ?>
+				<div class="wpml-pll-notices">
+					<?php foreach ( $errors as $error ) : ?>
+						<div class="notice notice-warning inline"><p><?php echo esc_html( $error ); ?></p></div>
+					<?php endforeach; ?>
+				</div>
+			<?php else : ?>
+				<form class="wpml-pll-form" data-tool="<?php echo esc_attr( $tool['id'] ); ?>">
+					<input type="hidden" name="action" value="<?php echo esc_attr( $tool['action'] ); ?>">
+					<?php wp_nonce_field( 'wpml-importer', '_wpnonce_wpml-importer' ); ?>
+					<button type="submit" class="button button-secondary">
+						<?php echo esc_html( $tool['button'] ); ?>
+					</button>
+					<div class="wpml-pll-status" id="wpml-status-<?php echo esc_attr( $tool['id'] ); ?>"></div>
+				</form>
+			<?php endif; ?>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Outputs scoped CSS for the page.
+	 *
+	 * @return void
+	 */
+	private function renderStyles() {
+		?>
+		<style>
+		.wpml-pll-wrap { max-width: 960px; }
+
+		.wpml-pll-heading {
+			font-size: 1.8em;
+			font-weight: 700;
+			margin-bottom: 4px;
+			color: #1d2327;
+		}
+
+		.wpml-pll-subtitle {
+			color: #646970;
+			margin-top: 0;
+			margin-bottom: 28px;
+			font-size: 14px;
+		}
+
+		.wpml-pll-section-title {
+			font-size: 1em;
+			font-weight: 600;
+			text-transform: uppercase;
+			letter-spacing: .06em;
+			color: #646970;
+			margin: 36px 0 4px;
+			border: none;
+		}
+
+		.wpml-pll-section-desc {
+			color: #646970;
+			margin-top: 0;
+			margin-bottom: 16px;
+			font-size: 13px;
+		}
+
+		/* Cards */
+		.wpml-pll-card {
+			background: #fff;
+			border: 1px solid #dcdcde;
+			border-radius: 6px;
+			padding: 20px 24px;
+			margin-bottom: 0;
+			box-shadow: 0 1px 3px rgba(0,0,0,.04);
+		}
+
+		.wpml-pll-card--primary {
+			border-left: 4px solid #2271b1;
+			margin-bottom: 28px;
+		}
+
+		.wpml-pll-tools-grid {
+			display: grid;
+			grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+			gap: 16px;
+		}
+
+		/* Card header */
+		.wpml-pll-card-header {
+			display: flex;
+			align-items: flex-start;
+			gap: 14px;
+			margin-bottom: 16px;
+		}
+
+		.wpml-pll-card-icon {
+			font-size: 26px;
+			color: #2271b1;
+			flex-shrink: 0;
+			margin-top: 2px;
+		}
+
+		.wpml-pll-card-header > div {
+			flex: 1;
+		}
+
+		.wpml-pll-card-title {
+			margin: 0 0 4px;
+			font-size: 1.05em;
+			font-weight: 600;
+			color: #1d2327;
+		}
+
+		.wpml-pll-card--primary .wpml-pll-card-title {
+			font-size: 1.2em;
+		}
+
+		.wpml-pll-card-desc {
+			margin: 0;
+			color: #646970;
+			font-size: 13px;
+			line-height: 1.5;
+		}
+
+		/* Badges */
+		.wpml-pll-badge {
+			display: inline-block;
+			flex-shrink: 0;
+			font-size: 10px;
+			font-weight: 700;
+			text-transform: uppercase;
+			letter-spacing: .05em;
+			padding: 3px 8px;
+			border-radius: 20px;
+			margin-top: 2px;
+		}
+
+		.wpml-pll-badge--once {
+			background: #fef8ee;
+			color: #a65a00;
+			border: 1px solid #f0c36d;
+		}
+
+		.wpml-pll-badge--repeatable {
+			background: #edfaef;
+			color: #1a7a38;
+			border: 1px solid #7dd49e;
+		}
+
+		/* Form area */
+		.wpml-pll-form {
+			display: flex;
+			align-items: center;
+			gap: 14px;
+			flex-wrap: wrap;
+		}
+
+		.wpml-pll-notices { margin-bottom: 0; }
+		.wpml-pll-notices .notice { margin: 4px 0 0; }
+
+		/* Status text */
+		.wpml-pll-status {
+			font-size: 13px;
+			color: #646970;
+			font-style: italic;
+		}
+
+		.wpml-pll-status.is-done {
+			color: #1a7a38;
+			font-style: normal;
+			font-weight: 600;
+		}
+
+		.wpml-pll-status.is-done::before {
+			content: "✓ ";
+		}
+		</style>
+		<?php
+	}
+
+	// -------------------------------------------------------------------------
+	// Error / pre-flight checks
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Pre-flight checks for the full migration (one-time).
 	 *
 	 * @return string[]
 	 */
-	protected function getErrors() {
+	private function getMainErrors() {
 		global $sitepress, $wp_version;
 
 		$checks = [];
@@ -171,7 +410,7 @@ class Page {
 		}
 
 		if ( ! empty( $sitepress ) ) {
-			$checks[] = __( 'WPML is activated. Please deactivate it.', 'wpml-to-polylang' );
+			$checks[] = __( 'WPML is still activated. Please deactivate it before running the import.', 'wpml-to-polylang' );
 		}
 
 		if ( ! defined( 'POLYLANG_VERSION' ) ) {
@@ -182,8 +421,49 @@ class Page {
 			}
 
 			if ( PLL()->model->languages->get_list() ) {
-				$checks[] = __( 'Polylang has already been installed on this website. Impossible to run the import.', 'wpml-to-polylang' );
+				$checks[] = __( 'Polylang is already configured on this site. The full migration can only be run once (before languages are set up). Use the individual tools below instead.', 'wpml-to-polylang' );
 			}
+		}
+
+		return $checks;
+	}
+
+	/**
+	 * Pre-flight checks shared by all standalone (repeatable) tools.
+	 *
+	 * Tool-specific checks are appended by the switch inside this method.
+	 *
+	 * @param string $toolId Tool identifier.
+	 * @return string[]
+	 */
+	private function getToolErrors( $toolId ) {
+		global $sitepress, $wp_version;
+
+		$checks = [];
+
+		if ( version_compare( $wp_version, WPML_TO_POLYLANG_MIN_WP_VERSION, '<' ) ) {
+			$checks[] = __( 'Your version of WordPress is too old. Please update.', 'wpml-to-polylang' );
+		}
+
+		if ( ! empty( $sitepress ) ) {
+			$checks[] = __( 'WPML is still activated. Please deactivate it before running this tool.', 'wpml-to-polylang' );
+		}
+
+		if ( ! defined( 'POLYLANG_VERSION' ) ) {
+			$checks[] = __( 'Please install and activate Polylang to run this tool.', 'wpml-to-polylang' );
+		} else {
+			if ( version_compare( POLYLANG_VERSION, WPML_TO_POLYLANG_MIN_PLL_VERSION, '<' ) ) {
+				$checks[] = __( 'Your version of Polylang is too old. Please update.', 'wpml-to-polylang' );
+			}
+
+			if ( ! PLL()->model->languages->get_list() ) {
+				$checks[] = __( 'No Polylang languages found. Please run the Full Migration first.', 'wpml-to-polylang' );
+			}
+		}
+
+		// Tool-specific checks.
+		if ( 'acf-options' === $toolId && ! defined( 'BEA_ACF_OPTIONS_FOR_POLYLANG_VERSION' ) ) {
+			$checks[] = __( '"ACF Options For Polylang" plugin is not active. Please install and activate it first.', 'wpml-to-polylang' );
 		}
 
 		return $checks;

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -23,11 +23,14 @@ class Plugin {
 	 * @return void
 	 */
 	public function init() {
+
+		// ── Full migration chain ──────────────────────────────────────────────
 		$actions = [
 			new Languages(),
 			new Posts(),
 			new Terms(),
 			new Menus(),
+			new NavMenuContent(),
 			new NoLangObjects(),
 			new Strings(),
 			new Options(),
@@ -35,17 +38,50 @@ class Plugin {
 		];
 
 		$nextAction = '';
-
 		foreach ( array_reverse( $actions ) as $action ) {
 			if ( ! empty( $nextAction ) ) {
 				$action->setNext( $nextAction );
 			}
-
 			$action->addHooks();
 			$nextAction = $action->getName();
 		}
 
+		// ── Standalone (repeatable) actions ───────────────────────────────────
+		$stringsAction    = new StandaloneStrings();
+		$acfOptionsAction = new AcfOptions();
+		$navMenuAction    = new StandaloneNavMenuContent();
+
+		$stringsAction->addHooks();
+		$acfOptionsAction->addHooks();
+		$navMenuAction->addHooks();
+
+		// ── Single unified admin page ─────────────────────────────────────────
 		$page = new Page( reset( $actions )->getName() );
+
+		$page->addTool(
+			'strings',
+			$stringsAction->getName(),
+			__( 'String Translations', 'wpml-to-polylang' ),
+			__( 'Re-import WPML string translations into Polylang. Safe to run multiple times — existing translations are overwritten with WPML values.', 'wpml-to-polylang' ),
+			__( 'Run String Import', 'wpml-to-polylang' )
+		);
+
+		$page->addTool(
+			'acf-options',
+			$acfOptionsAction->getName(),
+			__( 'ACF Options Migration', 'wpml-to-polylang' ),
+			__( 'Copies ACF options-page translations from the old slug-prefix format (options_fr_*) to the locale-prefix format (options_fr_FR_*) required by "ACF Options For Polylang" v2.0+.', 'wpml-to-polylang' ),
+			__( 'Run ACF Migration', 'wpml-to-polylang' )
+		);
+
+		$page->addTool(
+			'nav-menu',
+			$navMenuAction->getName(),
+			__( 'Fix Translated Menus', 'wpml-to-polylang' ),
+			__( 'Rewrites hardcoded English menu IDs inside translated post content (e.g. WPBakery nav_menu="56") so each language uses its own translated menu.', 'wpml-to-polylang' ),
+			__( 'Fix Menu References', 'wpml-to-polylang' )
+		);
+
 		$page->addHooks();
 	}
 }

--- a/src/StandaloneNavMenuContent.php
+++ b/src/StandaloneNavMenuContent.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * PHP version 5.6
+ *
+ * @package wpml-to-polylang
+ */
+
+namespace WP_Syntex\WPML_To_Polylang;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Standalone (repeatable) variant of NavMenuContent.
+ *
+ * Uses a distinct AJAX action name so it can be triggered from the admin page
+ * independently of the main migration chain without conflicting with the chained
+ * instance (which has a $next action set).
+ *
+ * @since 1.0
+ */
+class StandaloneNavMenuContent extends NavMenuContent {
+
+	/**
+	 * Returns the unique AJAX action name for the standalone tool.
+	 *
+	 * @return string
+	 */
+	public function getName() {
+		return 'process_standalone_nav_menu_content';
+	}
+}

--- a/src/StandaloneStrings.php
+++ b/src/StandaloneStrings.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * PHP version 5.6
+ *
+ * @package wpml-to-polylang
+ */
+
+namespace WP_Syntex\WPML_To_Polylang;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * String translations handler for the standalone, repeatable importer.
+ *
+ * Extends Strings with a distinct AJAX action name so it does not interfere
+ * with the main migration flow and can be run independently any number of times.
+ *
+ * @since 0.7
+ */
+class StandaloneStrings extends Strings {
+
+	/**
+	 * Returns the action name.
+	 *
+	 * @since 0.7
+	 *
+	 * @return string
+	 */
+	public function getName() {
+		return 'process_standalone_strings_translations';
+	}
+}

--- a/src/Strings.php
+++ b/src/Strings.php
@@ -39,6 +39,20 @@ class Strings extends AbstractSteppable {
 	}
 
 	/**
+	 * Contexts whose strings are per-post page-builder / block-editor content.
+	 * These should be imported into PLL_MO (for completeness) but NOT registered in
+	 * Polylang's WPML-compat string registry because they are too numerous and
+	 * are already handled through post translations.
+	 *
+	 * @var string[]
+	 */
+	const POST_CONTENT_CONTEXT_PREFIXES = [
+		'gutenberg-',
+		'page-builder-shortcode-strings-',
+		'page-builder-',
+	];
+
+	/**
 	 * Processes the strings translations.
 	 *
 	 * @since 0.5
@@ -52,8 +66,20 @@ class Strings extends AbstractSteppable {
 			return;
 		}
 
+		/*
+		 * Strings to register in Polylang's WPML-compat registry (polylang_wpml_strings).
+		 * Keyed by md5('context | name') — same convention used by PLL_WPML_Compat::register_string().
+		 * Deduplication is automatic because the same key simply overwrites with identical data.
+		 */
+		$stringsToRegister = [];
+
 		foreach ( $stringTranslations as $lang => $strings ) {
 			$language = PLL()->model->languages->get( $lang );
+
+			if ( empty( $language ) ) {
+				// Try a locale-based fallback (e.g. WPML 'pt-br' vs Polylang 'pt_BR').
+				$language = $this->getLanguageByLocale( $lang );
+			}
 
 			if ( empty( $language ) ) {
 				continue;
@@ -63,11 +89,120 @@ class Strings extends AbstractSteppable {
 			$mo->import_from_db( $language ); // Import strings saved in a previous step.
 
 			foreach ( $strings as $msg ) {
-				$mo->add_entry( $mo->make_entry( $msg[0], $msg[1] ) );
+				$original    = $msg['original'];
+				$translation = $msg['translation'];
+				$context     = ! empty( $msg['gettext_context'] ) ? $msg['gettext_context'] : null;
+				$wpmlContext = $msg['wpml_context'];
+				$wpmlName    = $msg['wpml_name'];
+
+				if ( null !== $context ) {
+					/*
+					 * Polylang's PLL_MO storage does not preserve gettext context, so we add both
+					 * a context-aware entry (for translate_entry() lookups with context) and a
+					 * context-free entry (so Polylang's export_to_db can find and persist the value).
+					 */
+					$contextEntry = new \Translation_Entry(
+						[
+							'singular'     => $original,
+							'context'      => $context,
+							'translations' => [ $translation ],
+						]
+					);
+					$mo->add_entry( $contextEntry );
+				}
+
+				// Always add a context-free entry so Polylang's translate() can find it.
+				$mo->add_entry( $mo->make_entry( $original, $translation ) );
+
+				// Register the string in Polylang's WPML-compat registry (not post-content).
+				if ( ! $this->isPostContentContext( $wpmlContext ) ) {
+					$key                      = md5( "$wpmlContext | $wpmlName" );
+					$stringsToRegister[ $key ] = [
+						'context'   => $wpmlContext,
+						'name'      => $wpmlName,
+						'string'    => $original,
+						'multiline' => true,
+						'icl'       => true,
+					];
+				}
 			}
 
 			$mo->export_to_db( $language );
 		}
+
+		$this->registerInPolylangWpmlStrings( $stringsToRegister );
+	}
+
+	/**
+	 * Returns true when a WPML string context represents per-post page-builder or
+	 * block-editor content rather than a reusable theme/plugin string.
+	 *
+	 * @since 0.7
+	 *
+	 * @param string $context WPML string context (= domain / group).
+	 * @return bool
+	 */
+	protected function isPostContentContext( $context ) {
+		foreach ( self::POST_CONTENT_CONTEXT_PREFIXES as $prefix ) {
+			if ( 0 === strpos( $context, $prefix ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Merges the given strings into the `polylang_wpml_strings` option that Polylang's
+	 * WPML-compat layer (PLL_WPML_Compat) reads to populate the Strings Translations UI.
+	 *
+	 * Existing entries are preserved; only new keys are added.
+	 *
+	 * @since 0.7
+	 *
+	 * @param array<string, array{context: string, name: string, string: string, multiline: bool, icl: bool}> $new Strings keyed by md5('context | name').
+	 * @return void
+	 */
+	protected function registerInPolylangWpmlStrings( array $new ) {
+		if ( empty( $new ) ) {
+			return;
+		}
+
+		$existing = get_option( 'polylang_wpml_strings', [] );
+
+		if ( ! is_array( $existing ) ) {
+			$existing = [];
+		}
+
+		// Existing entries take precedence; new ones fill in the gaps.
+		$merged = $new + $existing;
+
+		if ( count( $merged ) !== count( $existing ) ) {
+			update_option( 'polylang_wpml_strings', $merged, false );
+		}
+	}
+
+	/**
+	 * Attempts to find a Polylang language object by matching locale variants when the
+	 * WPML language code does not directly match a Polylang language slug.
+	 *
+	 * @since 0.7
+	 *
+	 * @param string $lang WPML language code (e.g. 'pt-br', 'zh-hans').
+	 * @return \PLL_Language|null
+	 */
+	protected function getLanguageByLocale( $lang ) {
+		$normalized = strtolower( str_replace( '-', '_', $lang ) );
+
+		foreach ( PLL()->model->languages->get_list() as $language ) {
+			if ( strtolower( str_replace( '-', '_', $language->locale ) ) === $normalized ) {
+				return $language;
+			}
+			if ( strtolower( str_replace( '-', '_', $language->slug ) ) === $normalized ) {
+				return $language;
+			}
+		}
+
+		return null;
 	}
 
 	/**
@@ -80,14 +215,17 @@ class Strings extends AbstractSteppable {
 	protected function getTotal() {
 		global $wpdb;
 
+		if ( ! $this->tableExists( 'icl_strings' ) || ! $this->tableExists( 'icl_string_translations' ) ) {
+			return 0;
+		}
+
 		return (int) $wpdb->get_var(
-			sprintf(
-				"SELECT COUNT(*)
-				FROM {$wpdb->prefix}icl_strings AS s
-				INNER JOIN {$wpdb->prefix}icl_string_translations AS st ON st.string_id = s.id
-				WHERE s.context NOT IN ( '%s' )",
-				implode( "', '", esc_sql( $this->getDomains() ) )
-			)
+			"SELECT COUNT(*)
+			FROM {$wpdb->prefix}icl_strings AS s
+			INNER JOIN {$wpdb->prefix}icl_string_translations AS st ON st.string_id = s.id
+			WHERE st.value IS NOT NULL
+			AND st.value != ''
+			AND ( s.language IS NULL OR s.language = '' OR s.language != st.language )"
 		);
 	}
 
@@ -96,10 +234,14 @@ class Strings extends AbstractSteppable {
 	 *
 	 * @since 0.5
 	 *
-	 * @return string[][][]
+	 * @return array<string, array<array{original: string, translation: string, gettext_context: string|null, wpml_context: string, wpml_name: string}>>
 	 */
 	protected function getWPMLStringsTranslations() {
 		global $wpdb;
+
+		if ( ! $this->tableExists( 'icl_strings' ) || ! $this->tableExists( 'icl_string_translations' ) ) {
+			return [];
+		}
 
 		$batch_size = $this->getBatchSyze();
 		$offset     = ( $this->step * $batch_size ) - $batch_size;
@@ -110,13 +252,15 @@ class Strings extends AbstractSteppable {
 		 * @var \stdClass[]
 		 */
 		$results = $wpdb->get_results(
-			sprintf(
-				"SELECT s.value AS string, st.language, st.value AS translation
+			$wpdb->prepare(
+				"SELECT s.value AS string, s.gettext_context, s.context AS wpml_context, s.name AS wpml_name,
+				        st.language, st.value AS translation
 				FROM {$wpdb->prefix}icl_strings AS s
 				INNER JOIN {$wpdb->prefix}icl_string_translations AS st ON st.string_id = s.id
-				WHERE s.context NOT IN ( '%s' )
+				WHERE st.value IS NOT NULL
+				AND st.value != ''
+				AND ( s.language IS NULL OR s.language = '' OR s.language != st.language )
 				LIMIT %d, %d",
-				implode( "', '", esc_sql( $this->getDomains() ) ),
 				absint( $offset ),
 				absint( $batch_size )
 			)
@@ -124,10 +268,15 @@ class Strings extends AbstractSteppable {
 
 		$stringTranslations = [];
 
-		// Order them in a convenient way.
 		foreach ( $results as $st ) {
-			if ( ! empty( $st->string ) & ! empty( $st->translation ) ) {
-				$stringTranslations[ $st->language ][] = [ $st->string, $st->translation ];
+			if ( ! empty( $st->string ) && ! empty( $st->translation ) ) {
+				$stringTranslations[ $st->language ][] = [
+					'original'        => $st->string,
+					'translation'     => $st->translation,
+					'gettext_context' => $st->gettext_context,
+					'wpml_context'    => (string) $st->wpml_context,
+					'wpml_name'       => (string) $st->wpml_name,
+				];
 			}
 		}
 
@@ -135,25 +284,15 @@ class Strings extends AbstractSteppable {
 	}
 
 	/**
-	 * Returns mo files text domains stored by WPML.
+	 * Checks whether a given table (without prefix) exists in the database.
 	 *
-	 * @since 0.5
+	 * @since 0.7
 	 *
-	 * @return string[]
+	 * @param string $table Table name without the WordPress prefix.
+	 * @return bool
 	 */
-	protected function getDomains() {
+	protected function tableExists( $table ) {
 		global $wpdb;
-
-		if ( ! $wpdb->get_var( "SHOW TABLES LIKE '{$wpdb->prefix}icl_mo_files_domains'" ) ) {
-			return [ '' ]; // A trick to avoid an empty NOT IN in sql query.
-		}
-
-		$domains = $wpdb->get_col( "SELECT DISTINCT domain FROM {$wpdb->prefix}icl_mo_files_domains" );
-
-		if ( empty( $domains ) ) {
-			return [ '' ];
-		}
-
-		return $domains;
+		return (bool) $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $wpdb->prefix . $table ) );
 	}
 }


### PR DESCRIPTION
## Summary

This branch completes the WPML → Polylang migration toolkit with several new capabilities and a redesigned admin UI.

### New features

- **String translations import** — queries `icl_strings` / `icl_string_translations`, writes translations into Polylang's `PLL_MO` storage, and populates `polylang_wpml_strings` so strings appear in Languages → Translations UI. Standalone repeatable tool added.
- **ACF Options migration** — copies ACF options-page data from the old slug-prefix format (`options_fr_*`) to the locale-prefix format (`options_fr_FR_*`) expected by "ACF Options For Polylang" v2.0+. Standalone repeatable tool added.
- **Nav-menu content rewriter** (`NavMenuContent`) — scans all non-default-language posts for hardcoded `nav_menu="X"` shortcode attributes (WPBakery Page Builder) and replaces each English menu ID with the WPML-recorded translation for that language. Runs automatically in the main chain and is also available as a standalone repeatable tool.
- **Unified admin page** — all tools consolidated under a single *Tools → WPML to Polylang* page. The Full Migration card (one-time, locked once Polylang languages exist) sits at the top; three repeatable tool cards sit below in a responsive grid. Each card has its own inline progress indicator and re-enables its button on completion.

### Files changed

| File | Change |
|---|---|
| `src/Strings.php` | Fetches `context`/`name` per string; populates `polylang_wpml_strings` |
| `src/AcfOptions.php` | New — migrates ACF options slug → locale format |
| `src/NavMenuContent.php` | New — rewrites nav_menu IDs in translated post content |
| `src/StandaloneStrings.php` | New — unique AJAX action for repeatable strings tool |
| `src/StandaloneNavMenuContent.php` | New — unique AJAX action for repeatable menu-fix tool |
| `src/Page.php` | Rewritten as unified multi-tool admin page |
| `src/Plugin.php` | Registers all actions + single page with tool cards |
| `js/index.js` | Rewritten to handle multiple independent forms per page |

### Removed
- `src/StringsPage.php`, `src/AcfOptionsPage.php`, `src/NavMenuContentPage.php` — replaced by the unified `Page.php`

## Test plan

- [ ] Run Full Migration on a fresh WPML site → all languages, posts, terms, menus, strings, options, ACF fields import correctly
- [ ] Verify Full Migration button is locked (notice shown) when Polylang languages already exist
- [ ] Run "String Translations" tool standalone → strings appear in Languages → Translations
- [ ] Run "ACF Options Migration" tool → ACF options-page fields populated per language
- [ ] Run "Fix Translated Menus" tool → WPBakery `nav_menu` attributes in translated posts updated to language-specific IDs
- [ ] Confirm each tool card shows its own inline progress and "✓ Done!" on completion
- [ ] Confirm running a repeatable tool a second time does not cause errors

Made with [Cursor](https://cursor.com)