### PR TITLE
Min PHP and WP Versions + Coding standards

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,7 +2,7 @@
 <ruleset name="WPML to Polylang">
 	<description>Coding standards for WPML to Polylang</description>
 
-	<arg name="extensions" value="php,js" />
+	<arg name="extensions" value="php" />
 	<arg name="colors"/>
 	<arg value="ps"/>
 
@@ -10,8 +10,8 @@
 
 	<arg name="basepath" value="."/>
 
-	<config name="testVersion" value="5.6-"/>
-	<config name="minimum_supported_wp_version" value="4.9"/>
+	<config name="testVersion" value="7.4-"/>
+	<config name="minimum_supported_wp_version" value="6.2"/>
 
 	<rule ref="Polylang">
 		<exclude name="Squiz.PHP.GlobalKeyword.NotAllowed" />

--- a/src/Page.php
+++ b/src/Page.php
@@ -107,7 +107,6 @@ class Page {
 			?>
 		</div>
 		<?php
-
 	}
 
 	/**

--- a/wpml-to-polylang.php
+++ b/wpml-to-polylang.php
@@ -14,7 +14,7 @@
  * Description:          Import multilingual data from WPML into Polylang
  * Version:              0.6
  * Requires at least:    5.8
- * Requires PHP:         5.6
+ * Requires PHP:         7.4
  * Author:               WP SYNTEX
  * Author URI:           https://polylang.pro
  * Text Domain:          wpml-to-polylang
@@ -44,7 +44,7 @@ namespace WP_Syntex\WPML_To_Polylang;
 defined( 'ABSPATH' ) || exit;
 
 define( 'WPML_TO_POLYLANG_VERSION', '0.6' );
-define( 'WPML_TO_POLYLANG_MIN_WP_VERSION', '5.8' );
+define( 'WPML_TO_POLYLANG_MIN_WP_VERSION', '6.2' );
 define( 'WPML_TO_POLYLANG_MIN_PLL_VERSION', '3.7' );
 
 if ( ! defined( 'WPML_TO_POLYLANG_QUERY_BATCH_SIZE' ) ) {


### PR DESCRIPTION
Raise min WP version to 6.2 (consequence of min Polylang version raised to 3.7).
Raise min PHP version to 7.4.
Fix a minor CS issue.