### PR TITLE
Fix predefined languages file in Polylang 3.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 	},
 	"scripts": {
 		"cs":"vendor/bin/phpcs",
-		"stan": "vendor/bin/phpstan analyze --memory-limit=400M",
+		"stan": "vendor/bin/phpstan analyze --memory-limit=1000M",
 		"lint": [
 			"@cs",
 			"@stan"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -11,7 +11,7 @@
 	<arg name="basepath" value="."/>
 
 	<config name="testVersion" value="7.4-"/>
-	<config name="minimum_supported_wp_version" value="6.2"/>
+	<config name="minimum_supported_wp_version" value="6.5"/>
 
 	<rule ref="Polylang">
 		<exclude name="Squiz.PHP.GlobalKeyword.NotAllowed" />

--- a/src/Languages.php
+++ b/src/Languages.php
@@ -46,7 +46,7 @@ class Languages extends AbstractAction {
 	 * @return void
 	 */
 	protected function handle() {
-		$predefinedLanguages = include POLYLANG_DIR . '/settings/languages.php';
+		$predefinedLanguages = include POLYLANG_DIR . '/src/settings/languages.php';
 
 		$wpmlLanguages = $this->getWPMLLanguages();
 		$wpmlLanguages = $this->orderLanguages( $wpmlLanguages );

--- a/wpml-to-polylang.php
+++ b/wpml-to-polylang.php
@@ -44,8 +44,8 @@ namespace WP_Syntex\WPML_To_Polylang;
 defined( 'ABSPATH' ) || exit;
 
 define( 'WPML_TO_POLYLANG_VERSION', '0.6' );
-define( 'WPML_TO_POLYLANG_MIN_WP_VERSION', '6.2' );
-define( 'WPML_TO_POLYLANG_MIN_PLL_VERSION', '3.7' );
+define( 'WPML_TO_POLYLANG_MIN_WP_VERSION', '6.5' );
+define( 'WPML_TO_POLYLANG_MIN_PLL_VERSION', '3.8' );
 
 if ( ! defined( 'WPML_TO_POLYLANG_QUERY_BATCH_SIZE' ) ) {
 	define( 'WPML_TO_POLYLANG_QUERY_BATCH_SIZE', 5000 ); // Limits the size of database queries.


### PR DESCRIPTION
Fix #30 

The path of the predefined languages files has moved (to `/src`) in Polylang 3.8. So the predefined flags (and also the text direction) are not filled in the parameters to create the languages.

A decision related to this issue is not to support versions older than 3.8. This automatically raises the min WP version to 6.5.