### PR TITLE
Fix database error with product cats

### DIFF
--- a/src/AbstractObjects.php
+++ b/src/AbstractObjects.php
@@ -106,7 +106,7 @@ abstract class AbstractObjects extends AbstractSteppable {
 		$relations = array_unique( $relations );
 
 		if ( ! empty( $relations ) ) {
-			$wpdb->query( "INSERT INTO {$wpdb->term_relationships} (object_id, term_taxonomy_id) VALUES " . implode( ',', $relations ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			$wpdb->query( "REPLACE {$wpdb->term_relationships} (object_id, term_taxonomy_id) VALUES " . implode( ',', $relations ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		}
 
 		foreach ( PLL()->model->languages->get_list() as $lang ) {

--- a/src/Languages.php
+++ b/src/Languages.php
@@ -61,38 +61,6 @@ class Languages extends AbstractAction {
 
 			PLL()->model->languages->add( $lang );
 		}
-
-		$this->cleanup();
-	}
-
-	/**
-	 * Deletes the language and translation group of the default category to avoid a conflict later.
-	 *
-	 * @since 0.5
-	 *
-	 * @return void
-	 */
-	protected function cleanup() {
-		$termIds = get_terms(
-			[
-				'taxonomy'   => 'term_translations',
-				'hide_empty' => false,
-				'fields'     => 'ids',
-			]
-		);
-
-		if ( is_array( $termIds ) ) {
-			foreach ( $termIds as $termId ) {
-				wp_delete_term( $termId, 'term_translations' );
-			}
-		}
-
-		$defaultCat = get_option( 'default_category' );
-		if ( is_numeric( $defaultCat ) ) {
-			wp_delete_object_term_relationships( (int) $defaultCat, 'term_language' );
-		}
-
-		PLL()->model->languages->clean_cache(); // Update the languages list.
 	}
 
 	/**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -47,5 +47,20 @@ class Plugin {
 
 		$page = new Page( reset( $actions )->getName() );
 		$page->addHooks();
+
+		add_action( 'pll_init', [ $this, 'fixConflicts' ], 999 ); // After PLLWC.
+	}
+
+	/**
+	 * Prevent Polylang for WooCommerce to create default product categories.
+	 *
+	 * @since 0.7
+	 *
+	 * @return void
+	 */
+	public function fixConflicts() {
+		if ( function_exists( 'PLLWC' ) ) {
+			remove_action( 'admin_init', [ PLLWC(), 'maybe_upgrade' ] );
+		}
 	}
 }


### PR DESCRIPTION
Fix #22 

Polylang for WooCommerce always creates default product cats in all languages if they don't exist. The language is thus already assigned when we attempt to assign languages found in WPML with `Term::processLanguages()`. This results in a DB error due to duplicate key.

This PR fixes the issue by using `REPLACE` by `INSERT`.

A second issue not reported in #22, but seen during my investigations is that we obtain 2 product cats in the default language, so I remove the action creating the default product cats to avoid this. The change in the DB query is still useful to replace the old method `Languages::cleanup()` which was used to remove the language of the default category. 