### PR TITLE
Add consistent version checks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,11 @@
 # Files to ignore when downloading a zip
 
 .gitattributes export-ignore
+.github/ export-ignore
 .gitignore export-ignore
 composer.json export-ignore
 composer.lock export-ignore
+consistent-versions-tag.yaml export-ignore
+consistent-versions.yaml export-ignore
 phpcs.xml.dist export-ignore
 phpstan.neon.dist export-ignore

--- a/.github/workflows/consistent-versions.yml
+++ b/.github/workflows/consistent-versions.yml
@@ -14,19 +14,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: "8.1"
-          coverage: none
-
-      - name: Install Consistent Versions
-        run: |
-          composer global require --no-interaction --prefer-dist "szepeviktor/consistent-versions:^1.2"
-          echo "$(composer global config bin-dir --absolute)" >> "$GITHUB_PATH"
-
-      - name: Check version consistency
-        run: consistent-versions check
-
-      - name: Check Git tag
-        if: github.ref_type == 'tag'
-        run: consistent-versions check consistent-versions-tag.yaml
+      # Temporary: point at the working branch until polylang/actions#23 is merged.
+      - uses: polylang/actions/consistent-versions@feat/consistent-versions-action

--- a/.github/workflows/consistent-versions.yml
+++ b/.github/workflows/consistent-versions.yml
@@ -14,5 +14,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Temporary: point at the working branch until polylang/actions#23 is merged.
-      - uses: polylang/actions/consistent-versions@feat/consistent-versions-action
+      - uses: polylang/actions/consistent-versions@main

--- a/.github/workflows/consistent-versions.yml
+++ b/.github/workflows/consistent-versions.yml
@@ -1,0 +1,32 @@
+name: Consistent versions
+
+on:
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    if: github.event.deleted == false
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.1"
+          coverage: none
+
+      - name: Install Consistent Versions
+        run: |
+          composer global require --no-interaction --prefer-dist "szepeviktor/consistent-versions:^1.2"
+          echo "$(composer global config bin-dir --absolute)" >> "$GITHUB_PATH"
+
+      - name: Check version consistency
+        run: consistent-versions check
+
+      - name: Check Git tag
+        if: github.ref_type == 'tag'
+        run: consistent-versions check consistent-versions-tag.yaml

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"require": {
-		"php": ">=5.6"
+		"php": ">=7.4"
 	},
 	"require-dev": {
 		"wpsyntex/polylang-cs": "dev-main",

--- a/consistent-versions-tag.yaml
+++ b/consistent-versions-tag.yaml
@@ -1,0 +1,21 @@
+checks:
+  release-tag:
+    normalize:
+      - trim-v-prefix
+      - version
+    expected:
+      reader: env
+      variable: GITHUB_REF_NAME
+    values:
+      plugin-constant:
+        reader: php
+        file: wpml-to-polylang.php
+        path: $.constants.WPML_TO_POLYLANG_VERSION
+      plugin-header:
+        reader: wordpress-plugin
+        file: wpml-to-polylang.php
+        path: $.Version
+      wordpress-readme:
+        reader: wordpress-readme
+        file: readme.txt
+        path: $['Stable tag']

--- a/consistent-versions.yaml
+++ b/consistent-versions.yaml
@@ -1,0 +1,58 @@
+checks:
+  release-version:
+    normalize: version
+    expected:
+      reader: php
+      file: wpml-to-polylang.php
+      path: $.constants.WPML_TO_POLYLANG_VERSION
+    values:
+      plugin-header:
+        reader: wordpress-plugin
+        file: wpml-to-polylang.php
+        path: $.Version
+      wordpress-readme:
+        reader: wordpress-readme
+        file: readme.txt
+        path: $['Stable tag']
+
+  minimum-php:
+    normalize: version
+    expected:
+      reader: composer
+      file: composer.json
+      path: $.require.php
+      normalize: composer-minimum
+    values:
+      plugin-header:
+        reader: wordpress-plugin
+        file: wpml-to-polylang.php
+        path: $['Requires PHP']
+      wordpress-readme:
+        reader: wordpress-readme
+        file: readme.txt
+        path: $['Requires PHP']
+      phpcs:
+        reader: phpcs
+        file: phpcs.xml.dist
+        path: $.config.testVersion
+        normalize: composer-minimum
+
+  minimum-wordpress:
+    normalize: version
+    expected:
+      reader: php
+      file: wpml-to-polylang.php
+      path: $.constants.WPML_TO_POLYLANG_MIN_WP_VERSION
+    values:
+      plugin-header:
+        reader: wordpress-plugin
+        file: wpml-to-polylang.php
+        path: $['Requires at least']
+      wordpress-readme:
+        reader: wordpress-readme
+        file: readme.txt
+        path: $['Requires at least']
+      phpcs:
+        reader: phpcs
+        file: phpcs.xml.dist
+        path: $.config.minimum_supported_wp_version

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -14,6 +14,7 @@
 	<config name="minimum_supported_wp_version" value="6.5"/>
 
 	<rule ref="Polylang">
+		<exclude name="PEAR.Commenting.FileComment.MissingVersion" />
 		<exclude name="Squiz.PHP.GlobalKeyword.NotAllowed" />
 		<exclude name="WordPress.DB.DirectDatabaseQuery.DirectQuery" />
 		<exclude name="WordPress.DB.DirectDatabaseQuery.NoCaching" />

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,9 @@
 Contributors: Chouby
 Donate link: https://polylang.pro
 Tags: Polylang, WPML, importer, multilingual, bilingual
-Requires at least: 5.8
+Requires at least: 6.5
 Tested up to: 6.7
+Requires PHP: 7.4
 Stable tag: 0.6
 License: GPLv3 or later
 

--- a/src/ACFFields.php
+++ b/src/ACFFields.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHP version 5.6
+ * Advanced Custom Fields import.
  *
  * @package wpml-to-polylang
  */

--- a/src/AbstractAction.php
+++ b/src/AbstractAction.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHP version 5.6
+ * Base action implementation.
  *
  * @package wpml-to-polylang
  */

--- a/src/AbstractObjects.php
+++ b/src/AbstractObjects.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHP version 5.6
+ * Base object import implementation.
  *
  * @package wpml-to-polylang
  */

--- a/src/AbstractSteppable.php
+++ b/src/AbstractSteppable.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHP version 5.6
+ * Base steppable action implementation.
  *
  * @package wpml-to-polylang
  */

--- a/src/Languages.php
+++ b/src/Languages.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHP version 5.6
+ * Language import.
  *
  * @package wpml-to-polylang
  */

--- a/src/Menus.php
+++ b/src/Menus.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHP version 5.6
+ * Navigation menu import.
  *
  * @package wpml-to-polylang
  */

--- a/src/NoLangObjects.php
+++ b/src/NoLangObjects.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHP version 5.6
+ * Import objects without a language.
  *
  * @package wpml-to-polylang
  */

--- a/src/Options.php
+++ b/src/Options.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHP version 5.6
+ * Plugin option import.
  *
  * @package wpml-to-polylang
  */

--- a/src/Page.php
+++ b/src/Page.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHP version 5.6
+ * Admin page.
  *
  * @package wpml-to-polylang
  */

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHP version 5.6
+ * Plugin bootstrap.
  *
  * @package wpml-to-polylang
  */

--- a/src/Posts.php
+++ b/src/Posts.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHP version 5.6
+ * Post import.
  *
  * @package wpml-to-polylang
  */

--- a/src/Strings.php
+++ b/src/Strings.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHP version 5.6
+ * String translation import.
  *
  * @package wpml-to-polylang
  */

--- a/src/Terms.php
+++ b/src/Terms.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHP version 5.6
+ * Term import.
  *
  * @package wpml-to-polylang
  */

--- a/wpml-to-polylang.php
+++ b/wpml-to-polylang.php
@@ -2,8 +2,6 @@
 /**
  * WPML to Polylang
  *
- * PHP version 5.6
- *
  * @package              wpml-to-polylang
  * @author               WP SYNTEX
  * @license              GPL-3.0-or-later
@@ -13,7 +11,7 @@
  * Plugin URI:           https://polylang.pro
  * Description:          Import multilingual data from WPML into Polylang
  * Version:              0.6
- * Requires at least:    5.8
+ * Requires at least:    6.5
  * Requires PHP:         7.4
  * Author:               WP SYNTEX
  * Author URI:           https://polylang.pro


### PR DESCRIPTION
Hello Chouby 👋

This adds an automated guard against version declarations drifting apart.

The repository currently repeats the plugin release, minimum PHP, and minimum
WordPress versions across the plugin header, readme, Composer configuration,
PHPCS configuration, and runtime constants. Some of those values had become
out of sync.

What changed:

- add Consistent Versions configuration for the release, PHP, and WordPress
  versions;
- compare Git tags with the plugin version on tagged pushes;
- run the checks on every push, installing the checker globally
  so it does not raise the plugin's own PHP requirement;
- 🐛 align the declared minimums with the existing runtime and PHPCS values:
  PHP 7.4 and WordPress 6.5;
- remove the duplicated PHP-version file docblocks and replace them with useful
  file descriptions;

This should make future releases safer without adding anything to the
distributed plugin or its development dependencies.

**This was my long time dream!**
